### PR TITLE
Validate metadata object against schema

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,13 +50,13 @@ The `Nipwaayoni\Tests\SchemaTestCase::SUPPORTED_SCHEMA_VERSIONS` is an array of 
 We prefer the [PSR-12](https://www.php-fig.org/psr/psr-12/) code style format for this project. The workflow executes a `php-cs-fixer` script to check the code style and will fail if violations are found. You can run the check yourself with `composer`:
 
 ```bash
-composer ci:fixer
+composer ci:cs-check
 ```
 
 You can also have `php-cs-fixer` apply fixes for you using:
 
 ```bash
-composer fix
+composer cs-fix
 ```
 
 The code style applies to the `src` and `tests` directories. 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,29 @@ composer ci:tests
 
 The workflow enforces passing tests, so make sure to check.
 
+## Schema Validation
+
+This package exists to push data to the APM service. The data emitted must adhere to the schema provided by the APM project. The APM projects makes the schema definition available for each release and we can use that to validate the data produced by this package.
+
+### Implement Schema Validation
+
+Your test class must extend `Nipwaayoni\Tests\SchemaTestCase` to perform schema validation. Implement the abstract methods as detailed in the associated PHPDoc blocks.
+
+The `testProducesValidJson()` provides the minimum test expected for validation. You should add more tests to cover any possible conditions which may alter the object structure resulting from the JSON serialization.
+
+### Add a New Schema Specification
+
+We will use version 7.8 for this example.
+
+1. Clone the [elastic/apm-server](https://github.com/elastic/apm-server) project
+2. Check out the desired version branch: `7.8`
+3. Create a new version directory in the project: `schema/apm-7.8/docs`
+4. Copy the spec directory to the new spec directory: `cp -r /path/to/apm-server/docs/spec /path/to/elastic-apm-php-agent/schema/apm-7.8/docs/spec`
+
+### Declare the New Version as Supported
+
+The `Nipwaayoni\Tests\SchemaTestCase::SUPPORTED_SCHEMA_VERSIONS` is an array of officially supported versions. Add the new version to that array, then locate and update all implementations of the `Nipwaayoni\Tests\SchemaTestCase::schemaVersionDataProvider()` data provider method to include the new version. 
+
 ## Code Style
 
 We prefer the [PSR-12](https://www.php-fig.org/psr/psr-12/) code style format for this project. The workflow executes a `php-cs-fixer` script to check the code style and will fail if violations are found. You can run the check yourself with `composer`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         command:
-          - fixer
+          - cs-check
         php-version:
           - 7.3
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Stable Version](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/v)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
 [![Total Downloads](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/downloads)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
 [![Latest Unstable Version](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/v/unstable)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
-[![Build Status](https://github.com/nipwaayoni/elastic-apm-php-agent/workflows/CI/badge.svg)](https://github.com/nipwaayoni/elastic-apm-php-agent)
+[![Build Status](https://github.com/nipwaayoni/elastic-apm-php-agent/workflows/CI/badge.svg)](https://github.com/nipwaayoni/elastic-apm-php-agent/actions?query=workflow%3ACI)
 [![License](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/license)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
 
 This is a community PHP agent for Elastic.co's [APM](https://www.elastic.co/solutions/apm) solution, supporting the `v2` Intake API. 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Stable Version](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/v)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
 [![Total Downloads](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/downloads)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
 [![Latest Unstable Version](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/v/unstable)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
-[![Build Status](https://travis-ci.org/nipwaayoni/elastic-apm-php-agent.svg?branch=master)](https://travis-ci.org/nipwaayoni/elastic-apm-php-agent)
+[![Build Status](https://github.com/nipwaayoni/elastic-apm-php-agent/workflows/CI/badge.svg)](https://github.com/nipwaayoni/elastic-apm-php-agent)
 [![License](https://poser.pugx.org/nipwaayoni/elastic-apm-php-agent/license)](//packagist.org/packages/nipwaayoni/elastic-apm-php-agent)
 
 This is a community PHP agent for Elastic.co's [APM](https://www.elastic.co/solutions/apm) solution, supporting the `v2` Intake API. 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
         "ext-curl" : "*",
         "ext-json": "*"
     },
+    "require-dev" : {
+        "justinrainbow/json-schema": "^5.2"
+    },
     "autoload" : {
         "psr-4" : {
             "Nipwaayoni\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         }
     ],
     "scripts": {
-        "fix": "\"./tools/php-cs-fixer\" --config=config/php-cs-fixer.php fix src/ tests/",
+        "cs-fix": "\"./tools/php-cs-fixer\" --config=config/php-cs-fixer.php fix src/ tests/",
         "ci:tests": "\"tools/phpunit\" tests/",
-        "ci:fixer": "\"./tools/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff src/ tests/"
+        "ci:cs-check": "\"./tools/php-cs-fixer\" --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff src/ tests/"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <phpunit bootstrap="./tests/bootstrap.php"
-  stopOnFailure="true"
+  stopOnFailure="false"
   stopOnError="false"
   colors="false"
   verbose="true"

--- a/schema/apm-6.7/docs/spec/common_system.json
+++ b/schema/apm-6.7/docs/spec/common_system.json
@@ -1,0 +1,22 @@
+{
+    "$id": "doc/spec/common_system.json",
+    "title": "System",
+    "type": ["object", "null"],
+    "properties": {
+        "architecture": {
+            "description": "Architecture of the system the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "hostname": {
+            "description": "Hostname of the system the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "platform": {
+            "description": "Name of the system platform the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-6.7/docs/spec/context.json
+++ b/schema/apm-6.7/docs/spec/context.json
@@ -1,0 +1,50 @@
+{
+    "$id": "doc/spec/context.json",
+    "title": "Context",
+    "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
+    "type": ["object", "null"],
+    "properties": {
+        "custom": {
+            "description": "An arbitrary mapping of additional metadata to store with the event.",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "^[^.*\"]*$": {}
+            },
+            "additionalProperties": false
+        },
+        "response": {
+            "type": ["object", "null"],
+            "properties": {
+                "finished": {
+                    "description": "A boolean indicating whether the response was finished or not",
+                    "type": ["boolean", "null"]
+                },
+                "headers": {
+                    "description": "A mapping of HTTP headers of the response object",
+                    "type": ["object", "null"],
+                    "properties": {
+                        "content-type": {
+                            "type": ["string", "null"]
+                        }
+                    }
+                },
+                "headers_sent": {
+                    "type": ["boolean", "null"]
+                },
+                "status_code": {
+                    "description": "The HTTP status code of the response.",
+                    "type": ["integer", "null"]
+                }
+            }
+        },
+        "request": {
+            "$ref": "request.json"
+        },
+        "tags": {
+            "$ref": "tags.json"
+        },
+        "user": {
+            "$ref": "user.json"
+        }
+    }
+}

--- a/schema/apm-6.7/docs/spec/errors/common_error.json
+++ b/schema/apm-6.7/docs/spec/errors/common_error.json
@@ -1,0 +1,95 @@
+{
+    "$id": "docs/spec/errors/common_error.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "properties": {
+        "context": {
+            "$ref": "./../context.json"
+        },
+        "culprit": {
+            "description": "Function call which was the primary perpetrator of this event.",
+            "type": ["string", "null"]
+        },
+        "exception": {
+            "description": "Information about the originally thrown error.",
+            "type": ["object", "null"],
+            "properties": {
+                "code": {
+                    "type": ["string", "integer", "null"],
+                    "maxLength": 1024,
+                    "description": "The error code set when the error happened, e.g. database error code."
+                },
+                "message": {
+                   "description": "The original error message.",
+                   "type": ["string", "null"]
+                },
+                "module": {
+                    "description": "Describes the exception type's module namespace.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "attributes": {
+                    "type": ["object", "null"]
+                },
+                "stacktrace": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "./../stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                },
+                "type": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "handled": {
+                    "type": ["boolean", "null"],
+                    "description": "Indicator whether the error was caught somewhere in the code or not."
+                }
+            },
+            "anyOf": [
+                {"required": ["message"], "properties": {"message": {"type": "string"}}},
+                {"required": ["type"], "properties": {"type": {"type": "string"}}}
+            ]
+        },
+        "log": {
+            "type": ["object", "null"],
+            "description": "Additional information added when logging the error.",
+            "properties": {
+                "level": {
+                    "description": "The severity of the record.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "logger_name": {
+                    "description": "The name of the logger instance used.",
+                    "type": ["string", "null"],
+                    "default": "default",
+                    "maxLength": 1024
+                },
+                "message": {
+                    "description": "The additionally logged error message.",
+                    "type": "string"
+                },
+                "param_message": {
+                    "description": "A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+
+                },
+                "stacktrace": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "./../stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                }
+            },
+            "required": ["message"]
+        }
+    },
+    "anyOf": [
+        { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
+        { "required": ["log"], "properties": {"log": { "type": "object" }} }
+    ]
+}

--- a/schema/apm-6.7/docs/spec/errors/v1_error.json
+++ b/schema/apm-6.7/docs/spec/errors/v1_error.json
@@ -1,0 +1,52 @@
+{
+    "$id": "docs/spec/errors/v1_error.json",
+    "title": "Errors payload",
+    "description": "List of errors wrapped in an object containing some other attributes normalized away from the errors themselves",
+    "type": "object",
+    "properties": {
+        "service": {
+            "$ref": "../service.json"
+        },
+        "process": {
+            "$ref": "../process.json"
+        },
+        "errors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "Data captured by an agent representing an event occurring in a monitored service",
+                "allOf": [
+
+                    { "$ref": "common_error.json"  },
+                    { "$ref": "../timestamp_rfc3339.json" },
+                    {  
+                        "properties": {
+                            "id": {
+                                "type": ["string", "null"],
+                                "description": "UUID for the error",
+                                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                            },
+                            "transaction": {
+                                "type": ["object", "null"],
+                                "description": "Data for correlating errors with transactions",
+                                "properties": {
+                                    "id": {
+                                        "type": ["string", "null"],
+                                        "description": "UUID for the transaction",
+                                        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+
+            },
+            "minItems": 1
+        },
+        "system": {
+            "$ref": "../v1_system.json"
+        }
+    },
+    "required": ["service", "errors"]
+}

--- a/schema/apm-6.7/docs/spec/errors/v2_error.json
+++ b/schema/apm-6.7/docs/spec/errors/v2_error.json
@@ -1,0 +1,53 @@
+{
+    "$id": "docs/spec/errors/v2_error.json",
+    "type": "object",
+    "description": "An error or a logged error message captured by an agent occurring in a monitored service",
+    "allOf": [
+
+        { "$ref": "common_error.json"  }, 
+        { "$ref": "../timestamp_epoch.json" },
+        {  
+            "properties": {
+                "id": {
+                    "type": ["string"],
+                    "description": "Hex encoded 128 random bits ID of the error.",
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.", 
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "transaction_id": {
+                    "type": ["string", "null"],
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction. Must be present if trace_id and parent_id are set.",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.", 
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "transaction": {
+                    "type": ["object", "null"],
+                    "description": "Data for correlating errors with transactions",
+                    "properties": {
+                        "sampled": {
+                            "type": ["boolean", "null"],
+                            "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                { "required": ["id"] },
+                { "if": {"required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}},
+                  "then": { "required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}} },
+                { "if": {"required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}},
+                  "then": { "required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}} },
+                { "if": {"required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}},
+                  "then": { "required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}} }
+            ]
+        }
+    ]
+}

--- a/schema/apm-6.7/docs/spec/metadata.json
+++ b/schema/apm-6.7/docs/spec/metadata.json
@@ -1,0 +1,21 @@
+{
+    "$id": "doc/spec/metadata.json",
+    "title": "Metadata",
+    "description": "Metadata concerning the other objects in the stream.",
+    "type": ["object"],
+    "properties": {
+        "service": {
+            "$ref": "service.json"
+        },
+        "process": {
+            "$ref": "process.json"
+        },
+        "system": {
+            "$ref": "v2_system.json"
+        },
+        "user": {
+            "$ref": "user.json"
+        }
+    },
+    "required": ["service"]
+}

--- a/schema/apm-6.7/docs/spec/metricsets/common_metricset.json
+++ b/schema/apm-6.7/docs/spec/metricsets/common_metricset.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metricsets/common_metricset.json",
+    "type": "object",
+    "description": "Metric data captured by an APM agent",
+    "properties": {
+        "samples": {
+            "type": ["object"],
+            "description": "Sampled application metrics collected from the agent.",
+            "patternProperties": {
+                "^[^*\"]*$": {
+                    "$ref": "sample.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tags": {
+            "$ref": "../tags.json"
+        }
+    },
+    "required": ["samples"]
+}

--- a/schema/apm-6.7/docs/spec/metricsets/payload.json
+++ b/schema/apm-6.7/docs/spec/metricsets/payload.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metricsets/payload.json",
+    "title": "Metrics payload",
+    "description": "Metrics for correlation with other APM data",
+    "type": "object",
+    "properties": {
+        "metrics": {
+            "type": "array",
+            "items": {
+                "$ref": "v1_metricset.json"
+            },
+            "minItems": 1
+        },
+        "process": {
+            "$ref": "../process.json"
+        },
+        "service": {
+            "$ref": "../service.json"
+        },
+        "system": {
+            "$ref": "../v1_system.json"
+        }
+    },
+    "required": ["service", "metrics"]
+}

--- a/schema/apm-6.7/docs/spec/metricsets/sample.json
+++ b/schema/apm-6.7/docs/spec/metricsets/sample.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metricsets/sample.json",
+    "type": ["object", "null"],
+    "description": "A single metric sample.",
+    "properties": {
+        "value": {"type": "number"}
+    },
+    "required": ["value"]
+}

--- a/schema/apm-6.7/docs/spec/metricsets/v1_metricset.json
+++ b/schema/apm-6.7/docs/spec/metricsets/v1_metricset.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/metricsets/v1_metricset.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "allOf": [
+
+        { "$ref": "common_metricset.json"  },
+        { "$ref": "../timestamp_rfc3339.json" },
+        {"required": ["timestamp"], "properties": {"timestamp": { "type": "string" }}}
+
+    ]
+}

--- a/schema/apm-6.7/docs/spec/metricsets/v2_metricset.json
+++ b/schema/apm-6.7/docs/spec/metricsets/v2_metricset.json
@@ -1,0 +1,11 @@
+{
+    "$id": "docs/spec/metricsets/v2_metricset.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "allOf": [
+
+        { "$ref": "common_metricset.json"  }, 
+        { "$ref": "../timestamp_epoch.json"},
+        {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}}
+    ]
+}

--- a/schema/apm-6.7/docs/spec/process.json
+++ b/schema/apm-6.7/docs/spec/process.json
@@ -1,0 +1,28 @@
+{
+  "$id": "doc/spec/process.json",
+  "title": "Process",
+  "type": ["object", "null"],
+  "properties": {
+      "pid": {
+          "description": "Process ID of the service",
+          "type": ["integer"]
+      },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["integer", "null"]
+      },
+      "title": {
+          "type": ["string", "null"],
+          "maxLength": 1024
+      },
+      "argv": {
+        "description": "Command line arguments used to start this process",
+        "type": ["array", "null"],
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
+    }
+  },
+  "required": ["pid"]
+}

--- a/schema/apm-6.7/docs/spec/request.json
+++ b/schema/apm-6.7/docs/spec/request.json
@@ -1,0 +1,106 @@
+{
+    "$id": "docs/spec/http.json",
+    "title": "Request",
+    "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
+    "type": ["object", "null"],
+    "properties": {
+        "body": {
+            "description": "Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.",
+            "type": ["object", "string", "null"]
+        },
+        "env": {
+            "description": "The env variable is a compounded of environment information passed from the webserver.",
+            "type": ["object", "null"],
+            "properties": {}
+        },
+        "headers": {
+            "description": "Should include any headers sent by the requester. Cookies will be taken by headers if supplied.",
+            "type": ["object", "null"],
+            "properties": {
+                "content-type": {
+                    "type": ["string", "null"]
+                },
+                "cookie": {
+                    "description": "Cookies sent with the request. It is expected to have values delimited by semicolons.",
+                    "type": ["string", "null"]
+                },
+                "user-agent": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "method": {
+            "description": "HTTP method.",
+            "type": "string",
+            "maxLength": 1024
+        },
+        "socket": {
+            "type": ["object", "null"],
+            "properties": {
+                "encrypted": {
+                    "description": "Indicates whether request was sent as SSL/HTTPS request.",
+                    "type": ["boolean", "null"]
+                },
+                "remote_address": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "url": {
+            "description": "A complete Url, with scheme, host and path.",
+            "type": "object",
+            "properties": {
+                "raw": {
+                    "type": ["string", "null"],
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
+                    "maxLength": 1024
+                },
+                "protocol": {
+                    "type": ["string", "null"],
+                    "description": "The protocol of the request, e.g. 'https:'.",
+                    "maxLength": 1024
+                },
+                "full": {
+                    "type": ["string", "null"],
+                    "description": "The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "maxLength": 1024
+                },
+                "hostname": {
+                    "type": ["string", "null"],
+                    "description": "The hostname of the request, e.g. 'example.com'.",
+                    "maxLength": 1024
+                },
+                "port": {
+                    "type": ["string", "null"],
+                    "description": "The port of the request, e.g. '443'",
+                    "maxLength": 1024
+                },
+                "pathname": {
+                    "type": ["string", "null"],
+                    "description": "The path of the request, e.g. '/search'",
+                    "maxLength": 1024
+                },
+                "search": {
+                    "description": "The search describes the query string of the request. It is expected to have values delimited by ampersands.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "hash": {
+                    "type": ["string", "null"],
+                    "description": "The hash of the request URL, e.g. 'top'",
+                    "maxLength": 1024
+                }
+            }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
+        }
+    },
+    "required": ["url", "method"]
+}

--- a/schema/apm-6.7/docs/spec/service.json
+++ b/schema/apm-6.7/docs/spec/service.json
@@ -1,0 +1,85 @@
+{
+    "$id": "doc/spec/service.json",
+    "title": "Service",
+    "type": "object",
+    "properties": {
+        "agent": {
+            "description": "Name and version of the Elastic APM agent",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                    "type": "string",
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name", "version"]
+        },
+        "framework": {
+            "description": "Name and version of the web framework used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "language": {
+            "description": "Name and version of the programming language used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name"]
+        },
+        "name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024
+        },
+        "environment": {
+            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "runtime": {
+            "description": "Name and version of the language runtime running this service",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": "string",
+                    "maxLength": 1024
+                }
+            },
+            "required": ["name", "version"]
+        },
+        "version": {
+            "description": "Version of the service emitting this event",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    },
+    "required": ["agent", "name"]
+}

--- a/schema/apm-6.7/docs/spec/sourcemaps/payload.json
+++ b/schema/apm-6.7/docs/spec/sourcemaps/payload.json
@@ -1,0 +1,28 @@
+{
+    "$id": "docs/spec/sourcemaps/sourcemap-metadata.json",
+    "title": "Sourcemap Metadata",
+    "description": "Sourcemap Metadata",
+    "type": "object",
+    "properties": {
+        "bundle_filepath": {
+            "description": "relative path of the minified bundle file",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_version": {
+            "description": "Version of the service emitting this event",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024,
+            "minLength": 1
+        }
+    },
+    "required": ["bundle_filepath", "service_name", "service_version"]
+}

--- a/schema/apm-6.7/docs/spec/spans/common_span.json
+++ b/schema/apm-6.7/docs/spec/spans/common_span.json
@@ -1,0 +1,83 @@
+{
+    "$id": "docs/spec/spans/common_span.json",
+    "type": "object",
+    "properties": {
+        "context": {
+            "type": ["object", "null"],
+            "description": "Any other arbitrary data captured by the agent, optionally provided by the user",
+            "properties": {
+                "db": {
+                    "type": ["object", "null"],
+                    "description": "An object containing contextual data for database spans",
+                    "properties": {
+                        "instance": {
+                           "type": ["string", "null"],
+                           "description": "Database instance name"
+                        },
+                        "statement": {
+                           "type": ["string", "null"],
+                           "description": "A database statement (e.g. query) for the given database type"
+                        },
+                        "type": {
+                           "type": ["string", "null"],
+                           "description": "Database type. For any SQL database, \"sql\". For others, the lower-case database category, e.g. \"cassandra\", \"hbase\", or \"redis\""
+                        },
+                        "user": {
+                           "type": ["string", "null"],
+                           "description": "Username for accessing database"
+                        }
+                    }
+                },
+                "http": {
+                    "type": ["object", "null"],
+                    "description": "An object containing contextual data of the related http request.",
+                    "properties": {
+                        "url": {
+                            "type": ["string", "null"],
+                            "description": "The raw url of the correlating http request."
+                        },
+                        "status_code": {
+                            "type": ["integer", "null"],
+                            "description": "The status code of the http request."
+                        },
+                        "method": {
+                            "type": ["string", "null"],
+                            "maxLength": 1024,
+                            "description": "The method of the http request."
+                        }
+                    }
+                },
+                "tags": {
+                    "$ref": "../tags.json"
+                }
+            }
+        },
+        "duration": {
+            "type": "number",
+            "description": "Duration of the span in milliseconds"
+        },
+        "name": {
+            "type": "string",
+            "description": "Generic designation of a span in the scope of a transaction",
+            "maxLength": 1024
+        },
+        "stacktrace": {
+            "type": ["array", "null"],
+            "description": "List of stack frames with variable attributes (eg: lineno, filename, etc)",
+            "items": {
+                "$ref": "../stacktrace_frame.json"
+            },
+            "minItems": 0
+        },
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
+            "maxLength": 1024
+        },
+        "sync": {
+            "type": ["boolean", "null"],
+            "description": "Indicates whether the span was executed synchronously or asynchronously."
+        }
+    },
+    "required": ["duration", "name", "type"]
+}

--- a/schema/apm-6.7/docs/spec/spans/v1_span.json
+++ b/schema/apm-6.7/docs/spec/spans/v1_span.json
@@ -1,0 +1,36 @@
+{
+    "$id": "docs/spec/spans/v1_span.json",
+    "type": "object",
+    "description": "An event captured by an agent occurring in a monitored service",
+    "allOf": [
+
+        { "$ref": "common_span.json"  }, 
+        {  
+            "properties": {
+                "id": {
+                    "description": "ID of the span.",
+                    "type": ["integer", "null"]
+                },
+                "transaction_id": {
+                    "type": "string",
+                    "description": "UUID of the enclosing transaction.",
+                    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                },       
+                "parent": {
+                    "type": ["integer", "null"],
+                    "description": "The ID of the parent of the span."
+                },
+                "start": {
+                    "type": "number",
+                    "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds."
+                }
+            },
+            "required": ["start"],
+            "dependencies": {
+                "parent": {
+                    "required": ["id"]
+                }
+            }
+        }
+    ]
+}

--- a/schema/apm-6.7/docs/spec/spans/v2_span.json
+++ b/schema/apm-6.7/docs/spec/spans/v2_span.json
@@ -1,0 +1,53 @@
+{
+    "$id": "docs/spec/spans/v2_span.json",
+    "type": "object",
+    "description": "An event captured by an agent occurring in a monitored service",
+    "allOf": [
+        { "$ref": "common_span.json"  },
+        { "$ref": "../timestamp_epoch.json" },
+        {  
+            "properties": {
+                "id": {
+                    "description": "Hex encoded 64 random bits ID of the span.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "transaction_id": {
+                    "type": "string",
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction.", 
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.", 
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.", 
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "start": {
+                    "type": ["number", "null"],
+                    "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
+                },
+                "subtype": {
+                    "type": ["string", "null"],
+                    "description": "A further sub-division of the type (e.g. postgresql, elasticsearch)",
+                    "maxLength": 1024
+                },
+                "action": {
+                    "type": ["string", "null"],
+                    "description": "The specific kind of event within the sub-type represented by the span (e.g. query, connect)",
+                    "maxLength": 1024
+                }
+            },
+            "required": ["id", "transaction_id", "trace_id", "parent_id"]
+        },
+        { "anyOf":[
+                {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}},
+                {"required": ["start"], "properties": {"start": { "type": "number" }}}
+            ]
+        }
+    ]
+}

--- a/schema/apm-6.7/docs/spec/stacktrace_frame.json
+++ b/schema/apm-6.7/docs/spec/stacktrace_frame.json
@@ -1,0 +1,62 @@
+{
+    "$id": "docs/spec/stacktrace_frame.json",
+    "title": "Stacktrace",
+    "type": "object",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
+    "properties": {
+        "abs_path": {
+            "description": "The absolute path of the file involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "colno": {
+            "description": "Column number",
+            "type": ["integer", "null"]
+        },
+        "context_line": {
+            "description": "The line of code part of the stack frame",
+            "type": ["string", "null"]
+        },
+        "filename": {
+            "description": "The relative filename of the code involved in the stack frame, used e.g. to do error checksumming",
+            "type": "string"
+        },
+        "function": {
+            "description": "The function involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "library_frame": {
+            "description": "A boolean, indicating if this frame is from a library or user code",
+            "type": ["boolean", "null"]
+        },
+        "lineno": {
+            "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
+            "type": "integer"
+        },
+        "module": {
+            "description": "The module to which frame belongs to",
+            "type": ["string", "null"]
+        },
+        "post_context": {
+            "description": "The lines of code after the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "pre_context": {
+            "description": "The lines of code before the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "vars": {
+            "description": "Local variables for this stack frame",
+            "type": ["object", "null"],
+            "properties": {}
+        }
+    },
+    "required": ["filename", "lineno"]
+}

--- a/schema/apm-6.7/docs/spec/tags.json
+++ b/schema/apm-6.7/docs/spec/tags.json
@@ -1,0 +1,13 @@
+{
+    "$id": "doc/spec/tags.json",
+    "title": "Tags",
+    "type": ["object", "null"],
+    "description": "A flat mapping of user-defined tags with string, boolean or number values.",
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["string", "boolean", "number", "null"],
+            "maxLength": 1024
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema/apm-6.7/docs/spec/timestamp_epoch.json
+++ b/schema/apm-6.7/docs/spec/timestamp_epoch.json
@@ -1,0 +1,12 @@
+{
+    "$id": "doc/spec/timestamp_epoch.json",
+    "title": "Timestamp Epoch",
+    "description": "Object with 'timestamp' property.",
+    "type": ["object"],
+    "properties": {  
+        "timestamp": {
+            "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
+            "type": ["integer", "null"]
+        }
+    }
+}

--- a/schema/apm-6.7/docs/spec/timestamp_rfc3339.json
+++ b/schema/apm-6.7/docs/spec/timestamp_rfc3339.json
@@ -1,0 +1,14 @@
+{
+    "$id": "doc/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
+    "type": ["object"],
+    "properties": {
+        "timestamp": {
+            "type": ["string", "null"],
+            "pattern": "Z$",
+            "format": "date-time",
+            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
+        }
+    }
+}

--- a/schema/apm-6.7/docs/spec/transactions/common_transaction.json
+++ b/schema/apm-6.7/docs/spec/transactions/common_transaction.json
@@ -1,0 +1,44 @@
+{
+    "$id": "docs/spec/transactions/common_transaction.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "properties": {
+        "context": {
+            "$ref": "../context.json"
+        },
+        "duration": {
+            "type": "number",
+            "description": "How long the transaction took to complete, in ms with 3 decimal points"
+        },
+        "name": {
+            "type": ["string","null"],
+            "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
+            "maxLength": 1024
+        },
+        "result": {
+            "type": ["string", "null"],
+            "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
+            "maxLength": 1024
+        },
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+            "maxLength": 1024
+        },
+        "marks": {
+            "type": ["object", "null"],
+            "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
+            "patternProperties": {
+                "^[^.*\"]*$": {
+                    "$ref": "mark.json"
+                }
+            },
+            "additionalProperties": false
+        },
+        "sampled": {
+            "type": ["boolean", "null"],
+            "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+        }
+    },
+    "required": ["duration", "type"]
+}

--- a/schema/apm-6.7/docs/spec/transactions/mark.json
+++ b/schema/apm-6.7/docs/spec/transactions/mark.json
@@ -1,0 +1,11 @@
+{
+    "$id": "docs/spec/transactions/mark.json",
+    "type": ["object", "null"],
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["number", "null"]
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema/apm-6.7/docs/spec/transactions/v1_transaction.json
+++ b/schema/apm-6.7/docs/spec/transactions/v1_transaction.json
@@ -1,0 +1,61 @@
+{
+    "$id": "docs/spec/transactions/v1_transaction.json",
+    "title": "Transactions payload",
+    "description": "List of transactions wrapped in an object containing some other attributes normalized away from the transactions themselves",
+    "type": "object",
+    "properties": {
+        "service": {
+            "$ref": "../service.json"
+        },
+        "process": {
+            "$ref": "../process.json"
+        },
+        "system": {
+            "$ref": "../v1_system.json"
+        },
+        "transactions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "Data captured by an agent representing an event occurring in a monitored service",
+                "allOf": [
+                    { "$ref": "common_transaction.json"  }, 
+                    { "$ref": "../timestamp_rfc3339.json" },
+                    {  
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "UUID for the transaction, referred by its spans",
+                                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+                            },
+                            "spans": {
+                                "type": ["array", "null"],
+                                "items": {
+                                    "$ref": "./../spans/v1_span.json"
+                                },
+                                "minItems": 0
+                            },
+                            "span_count": {
+                                "type": ["object", "null"],
+                                "properties": {
+                                    "dropped": {
+                                        "type": ["object", "null"],
+                                        "properties": {
+                                            "total": {
+                                                "type": ["integer","null"],
+                                                "description": "number of spans that have been dropped by the agent recording the transaction."
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "required": ["id"]
+                    }
+                ]
+            },
+            "minItems": 1
+        }
+    },
+    "required": ["service", "transactions"]
+}

--- a/schema/apm-6.7/docs/spec/transactions/v2_transaction.json
+++ b/schema/apm-6.7/docs/spec/transactions/v2_transaction.json
@@ -1,0 +1,45 @@
+{
+    "$id": "docs/spec/transactions/v2_transaction.json",
+    "type": "object",
+    "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
+    "allOf": [
+        { "$ref": "common_transaction.json"  },
+        { "$ref": "../timestamp_epoch.json" },
+        {  
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Hex encoded 64 random bits ID of the transaction.", 
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.", 
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Only root transactions of a trace do not have a parent_id, otherwise it needs to be set.", 
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "span_count": {
+                    "type": "object",
+                    "properties": {
+                        "started": {
+                            "type": "integer",
+                            "description": "Number of correlated spans that are recorded."
+
+                        },
+                        "dropped": {
+                            "type": ["integer","null"],
+                            "description": "Number of spans that have been dropped by the agent recording the transaction."
+
+                        }
+                    },
+                    "required": ["started"]
+                }
+            },
+            "required": ["id", "trace_id", "span_count"]
+        }
+    ]
+}

--- a/schema/apm-6.7/docs/spec/user.json
+++ b/schema/apm-6.7/docs/spec/user.json
@@ -1,0 +1,23 @@
+{
+    "$id": "docs/spec/user.json",
+    "title": "User",
+    "description": "Describes the authenticated User for a request.",
+    "type": ["object", "null"],
+    "properties": {
+        "id": {
+            "description": "Identifier of the logged in user, e.g. the primary key of the user",
+            "type": ["string", "integer", "null"],
+            "maxLength": 1024
+        },
+        "email": {
+            "description": "Email of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "username": {
+            "description": "The username of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-6.7/docs/spec/v1_system.json
+++ b/schema/apm-6.7/docs/spec/v1_system.json
@@ -1,0 +1,8 @@
+{
+    "$id": "doc/spec/v1_system.json",
+    "title": "System",
+    "type": ["object", "null"],
+    "allOf": [
+        { "$ref": "common_system.json"  }
+    ]
+}

--- a/schema/apm-6.7/docs/spec/v2_system.json
+++ b/schema/apm-6.7/docs/spec/v2_system.json
@@ -1,0 +1,54 @@
+{
+    "$id": "doc/spec/v2_system.json",
+    "title": "System",
+    "type": ["object", "null"],
+    "allOf": [
+        { "$ref": "common_system.json"  },
+        {
+            "properties": {
+                "kubernetes": {
+                    "properties": {
+                        "namespace": {
+                            "description": "Kubernetes namespace",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "pod":{
+                            "properties": {
+                                "name": {
+                                    "description": "Kubernetes pod name",
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024
+                                },
+                                "uid": {
+                                    "description": "Kubernetes pod uid",
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024
+                                }
+                            }
+                        },
+                        "node":{
+                            "properties": {
+                                "name": {
+                                    "description": "Kubernetes node name",
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024
+                                }
+                            }
+                        }
+                    }
+                },
+                "container": {
+                    "properties": {
+                        "id" : {
+                            "description": "Container ID",
+                            "type": ["string"],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": ["id"]
+                }
+            }
+        }
+    ]
+}

--- a/schema/apm-7.6/docs/spec/context.json
+++ b/schema/apm-7.6/docs/spec/context.json
@@ -1,0 +1,75 @@
+{
+    "$id": "doc/spec/context.json",
+    "title": "Context",
+    "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
+    "type": ["object", "null"],
+    "properties": {
+        "custom": {
+            "description": "An arbitrary mapping of additional metadata to store with the event.",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "^[^.*\"]*$": {}
+            },
+            "additionalProperties": false
+        },
+        "response": {
+            "type": ["object", "null"],
+            "properties": {
+                "finished": {
+                    "description": "A boolean indicating whether the response was finished or not",
+                    "type": ["boolean", "null"]
+                },
+                "headers": {
+                    "description": "A mapping of HTTP headers of the response object",
+                    "type": ["object", "null"],
+                    "patternProperties": {
+                        "[.*]*$": {
+                            "type": ["string", "array", "null"],
+                            "items": {
+                                "type": ["string"]
+                            }
+                        }
+                    }
+                },
+                "headers_sent": {
+                    "type": ["boolean", "null"]
+                },
+                "status_code": {
+                    "description": "The HTTP status code of the response.",
+                    "type": ["integer", "null"]
+                }
+            }
+        },
+        "request": {
+            "$ref": "request.json"
+        },
+        "tags": {
+            "$ref": "tags.json"
+        },
+        "user": {
+            "description": "Describes the correlated user for this event. If user data are provided here, all user related information from metadata is ignored, otherwise the metadata's user information will be stored with the event.",
+            "$ref": "user.json"
+        },
+        "page": {
+            "description": "",
+            "type": ["object", "null"],
+            "properties": {
+                "referer": {
+                    "description": "RUM specific field that stores the URL of the page that 'linked' to the current page.",
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "description": "RUM specific field that stores the URL of the current page",
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "service": {
+            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+            "$ref": "service.json"
+        },
+        "message": {
+            "$ref": "message.json"
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/errors/error.json
+++ b/schema/apm-7.6/docs/spec/errors/error.json
@@ -1,0 +1,154 @@
+{
+    "$id": "docs/spec/errors/error.json",
+    "type": "object",
+    "description": "An error or a logged error message captured by an agent occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        {
+            "properties": {
+                "id": {
+                    "type": ["string"],
+                    "description": "Hex encoded 128 random bits ID of the error.",
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "transaction_id": {
+                    "type": ["string", "null"],
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction. Must be present if trace_id and parent_id are set.",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "transaction": {
+                    "type": ["object", "null"],
+                    "description": "Data for correlating errors with transactions",
+                    "properties": {
+                        "sampled": {
+                            "type": ["boolean", "null"],
+                            "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                        },
+                        "type": {
+                            "type": ["string", "null"],
+                            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "context": {
+                    "$ref": "./../context.json"
+                },
+                "culprit": {
+                    "description": "Function call which was the primary perpetrator of this event.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "exception": {
+                    "description": "Information about the originally thrown error.",
+                    "type": ["object", "null"],
+                    "properties": {
+                        "code": {
+                            "type": ["string", "integer", "null"],
+                            "maxLength": 1024,
+                            "description": "The error code set when the error happened, e.g. database error code."
+                        },
+                        "message": {
+                            "description": "The original error message.",
+                            "type": ["string", "null"]
+                        },
+                        "module": {
+                            "description": "Describes the exception type's module namespace.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "attributes": {
+                            "type": ["object", "null"]
+                        },
+                        "stacktrace": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "$ref": "./../stacktrace_frame.json"
+                            },
+                            "minItems": 0
+                        },
+                        "type": {
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "handled": {
+                            "type": ["boolean", "null"],
+                            "description": "Indicator whether the error was caught somewhere in the code or not."
+                        },
+                        "cause": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "type": ["object", "null"],
+                                "description": "Recursive exception object"
+                            },
+                            "minItems": 0,
+                            "description": "Exception tree"
+                        }
+                    },
+                    "anyOf": [
+                        {"required": ["message"], "properties": {"message": {"type": "string"}}},
+                        {"required": ["type"], "properties": {"type": {"type": "string"}}}
+                    ]
+                },
+                "log": {
+                    "type": ["object", "null"],
+                    "description": "Additional information added when logging the error.",
+                    "properties": {
+                        "level": {
+                            "description": "The severity of the record.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "logger_name": {
+                            "description": "The name of the logger instance used.",
+                            "type": ["string", "null"],
+                            "default": "default",
+                            "maxLength": 1024
+                        },
+                        "message": {
+                            "description": "The additionally logged error message.",
+                            "type": "string"
+                        },
+                        "param_message": {
+                            "description": "A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+
+                        },
+                        "stacktrace": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "$ref": "./../stacktrace_frame.json"
+                            },
+                            "minItems": 0
+                        }
+                    },
+                    "required": ["message"]
+                }
+            },
+            "allOf": [
+                { "required": ["id"] },
+                { "if": {"required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}},
+                    "then": { "required": ["trace_id", "parent_id"], "properties": {"trace_id": { "type": "string" }, "parent_id": {"type": "string"}}}},
+                { "if": {"required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}},
+                    "then": { "required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}} },
+                { "if": {"required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}},
+                    "then": { "required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}} }
+            ],
+            "anyOf": [
+                { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
+                { "required": ["log"], "properties": {"log": { "type": "object" }} }
+            ]
+        }
+    ]
+}

--- a/schema/apm-7.6/docs/spec/message.json
+++ b/schema/apm-7.6/docs/spec/message.json
@@ -1,0 +1,43 @@
+{
+    "$id": "doc/spec/message.json",
+    "title": "Message",
+    "description": "Details related to message receiving and publishing if the captured event integrates with a messaging system",
+    "type": ["object", "null"],
+    "properties": {
+        "queue": {
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "description": "Name of the message queue where the message is received.",
+                    "type": ["string","null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "age": {
+            "type": ["object", "null"],
+            "properties": {
+                "ms": {
+                    "description": "The age of the message in milliseconds. If the instrumented messaging framework provides a timestamp for the message, agents may use it. Otherwise, the sending agent can add a timestamp in milliseconds since the Unix epoch to the message's metadata to be retrieved by the receiving agent. If a timestamp is not available, agents should omit this field.",
+                    "type": ["integer", "null"]
+                }
+            }
+        },
+        "body": {
+            "description": "messsage body, similar to an http request body",
+            "type": ["string", "null"]
+        },
+        "headers": {
+            "description": "messsage headers, similar to http request headers",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "[.*]*$": {
+                    "type": ["string", "array", "null"],
+                    "items": {
+                        "type": ["string"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/metadata.json
+++ b/schema/apm-7.6/docs/spec/metadata.json
@@ -1,0 +1,37 @@
+{
+    "$id": "doc/spec/metadata.json",
+    "title": "Metadata",
+    "description": "Metadata concerning the other objects in the stream.",
+    "type": ["object"],
+    "properties": {
+        "service": {
+            "$ref": "service.json",
+            "type": "object",
+            "required": ["name", "agent"],
+            "properties.name.type": "string",
+            "properties.agent.type": "string",
+            "properties.agent.required": ["name", "version"],
+            "properties.agent.properties.name.type": "string",
+            "properties.agent.properties.version.type": "string",
+            "properties.runtime.required": ["name", "version"],
+            "properties.runtime.properties.name.type": "string",
+            "properties.runtime.properties.version.type": "string",
+            "properties.language.required": ["name"],
+            "properties.language.properties.name.type": "string"
+        },
+        "process": {
+            "$ref": "process.json"
+        },
+        "system": {
+            "$ref": "system.json"
+        },
+        "user": {
+            "description": "Describes the authenticated User for a request.",
+            "$ref": "user.json"
+        },
+        "labels": {
+            "$ref": "tags.json"
+        }
+    },
+    "required": ["service"]
+}

--- a/schema/apm-7.6/docs/spec/metricsets/metricset.json
+++ b/schema/apm-7.6/docs/spec/metricsets/metricset.json
@@ -1,0 +1,32 @@
+{
+    "$id": "docs/spec/metricsets/metricset.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json"},
+        { "$ref": "../span_type.json" },
+        { "$ref": "../span_subtype.json" },
+        { "$ref": "../transaction_name.json" },
+        { "$ref": "../transaction_type.json" },
+        {
+            "properties": {
+                "samples": {
+                    "type": [
+                        "object"
+                    ],
+                    "description": "Sampled application metrics collected from the agent.",
+                    "patternProperties": {
+                        "^[^*\"]*$": {
+                            "$ref": "sample.json"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "tags": {
+                    "$ref": "../tags.json"
+                }
+            },
+            "required": ["samples"]
+        }
+    ]
+}

--- a/schema/apm-7.6/docs/spec/metricsets/sample.json
+++ b/schema/apm-7.6/docs/spec/metricsets/sample.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metricsets/sample.json",
+    "type": ["object", "null"],
+    "description": "A single metric sample.",
+    "properties": {
+        "value": {"type": "number"}
+    },
+    "required": ["value"]
+}

--- a/schema/apm-7.6/docs/spec/process.json
+++ b/schema/apm-7.6/docs/spec/process.json
@@ -1,0 +1,28 @@
+{
+  "$id": "doc/spec/process.json",
+  "title": "Process",
+  "type": ["object", "null"],
+  "properties": {
+      "pid": {
+          "description": "Process ID of the service",
+          "type": ["integer"]
+      },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["integer", "null"]
+      },
+      "title": {
+          "type": ["string", "null"],
+          "maxLength": 1024
+      },
+      "argv": {
+        "description": "Command line arguments used to start this process",
+        "type": ["array", "null"],
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
+    }
+  },
+  "required": ["pid"]
+}

--- a/schema/apm-7.6/docs/spec/request.json
+++ b/schema/apm-7.6/docs/spec/request.json
@@ -1,0 +1,103 @@
+{
+    "$id": "docs/spec/http.json",
+    "title": "Request",
+    "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
+    "type": ["object", "null"],
+    "properties": {
+        "body": {
+            "description": "Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.",
+            "type": ["object", "string", "null"]
+        },
+        "env": {
+            "description": "The env variable is a compounded of environment information passed from the webserver.",
+            "type": ["object", "null"],
+            "properties": {}
+        },
+        "headers": {
+            "description": "Should include any headers sent by the requester. Cookies will be taken by headers if supplied.",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "[.*]*$": {
+                    "type": ["string", "array", "null"],
+                    "items": {
+                        "type": ["string"]
+                    }
+                }
+            }
+        },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "method": {
+            "description": "HTTP method.",
+            "type": "string",
+            "maxLength": 1024
+        },
+        "socket": {
+            "type": ["object", "null"],
+            "properties": {
+                "encrypted": {
+                    "description": "Indicates whether request was sent as SSL/HTTPS request.",
+                    "type": ["boolean", "null"]
+                },
+                "remote_address": {
+                    "description": "The network address sending the request. Should be obtained through standard APIs and not parsed from any headers like 'Forwarded'.",
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "url": {
+            "description": "A complete Url, with scheme, host and path.",
+            "type": "object",
+            "properties": {
+                "raw": {
+                    "type": ["string", "null"],
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
+                    "maxLength": 1024
+                },
+                "protocol": {
+                    "type": ["string", "null"],
+                    "description": "The protocol of the request, e.g. 'https:'.",
+                    "maxLength": 1024
+                },
+                "full": {
+                    "type": ["string", "null"],
+                    "description": "The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "maxLength": 1024
+                },
+                "hostname": {
+                    "type": ["string", "null"],
+                    "description": "The hostname of the request, e.g. 'example.com'.",
+                    "maxLength": 1024
+                },
+                "port": {
+                    "type": ["string", "integer","null"],
+                    "description": "The port of the request, e.g. '443'",
+                    "maxLength": 1024
+                },
+                "pathname": {
+                    "type": ["string", "null"],
+                    "description": "The path of the request, e.g. '/search'",
+                    "maxLength": 1024
+                },
+                "search": {
+                    "description": "The search describes the query string of the request. It is expected to have values delimited by ampersands.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "hash": {
+                    "type": ["string", "null"],
+                    "description": "The hash of the request URL, e.g. 'top'",
+                    "maxLength": 1024
+                }
+            }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
+        }
+    },
+    "required": ["url", "method"]
+}

--- a/schema/apm-7.6/docs/spec/service.json
+++ b/schema/apm-7.6/docs/spec/service.json
@@ -1,0 +1,96 @@
+{
+    "$id": "doc/spec/service.json",
+    "title": "Service",
+    "type": ["object", "null"],
+    "properties": {
+        "agent": {
+            "description": "Name and version of the Elastic APM agent",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "ephemeral_id": {
+                    "description": "Free format ID used for metrics correlation by some agents",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "framework": {
+            "description": "Name and version of the web framework used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "language": {
+            "description": "Name and version of the programming language used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": ["string", "null"],
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024
+        },
+        "environment": {
+            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "runtime": {
+            "description": "Name and version of the language runtime running this service",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "version": {
+            "description": "Version of the service emitting this event",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "node": {
+            "description": "Unique meaningful name of the service node.",
+            "type": ["object", "null"],
+            "properties": {
+                "configured_name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/sourcemaps/payload.json
+++ b/schema/apm-7.6/docs/spec/sourcemaps/payload.json
@@ -1,0 +1,28 @@
+{
+    "$id": "docs/spec/sourcemaps/sourcemap-metadata.json",
+    "title": "Sourcemap Metadata",
+    "description": "Sourcemap Metadata",
+    "type": "object",
+    "properties": {
+        "bundle_filepath": {
+            "description": "relative path of the minified bundle file",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_version": {
+            "description": "Version of the service emitting this event",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024,
+            "minLength": 1
+        }
+    },
+    "required": ["bundle_filepath", "service_name", "service_version"]
+}

--- a/schema/apm-7.6/docs/spec/span_subtype.json
+++ b/schema/apm-7.6/docs/spec/span_subtype.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/span_subtype.json",
+    "title": "Span Subtype",
+    "type": ["object"],
+    "properties": {
+        "subtype": {
+            "type": ["string", "null"],
+            "description": "A further sub-division of the type (e.g. postgresql, elasticsearch)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/span_type.json
+++ b/schema/apm-7.6/docs/spec/span_type.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/span_type.json",
+    "title": "Span Type",
+    "type": ["object"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/spans/span.json
+++ b/schema/apm-7.6/docs/spec/spans/span.json
@@ -1,0 +1,213 @@
+{
+    "$id": "docs/spec/spans/span.json",
+    "type": "object",
+    "description": "An event captured by an agent occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        { "$ref": "../span_type.json" },
+        { "$ref": "../span_subtype.json" },
+        {
+            "properties": {
+                "id": {
+                    "description": "Hex encoded 64 random bits ID of the span.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "transaction_id": {
+                    "type": ["string", "null"],
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction.",
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "start": {
+                    "type": ["number", "null"],
+                    "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
+                },
+                "action": {
+                    "type": ["string", "null"],
+                    "description": "The specific kind of event within the sub-type represented by the span (e.g. query, connect)",
+                    "maxLength": 1024
+                },
+                "context": {
+                    "type": ["object", "null"],
+                    "description": "Any other arbitrary data captured by the agent, optionally provided by the user",
+                    "properties": {
+                        "destination": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data about the destination for spans",
+                            "properties": {
+                                "address": {
+                                    "type": ["string", "null"],
+                                    "description": "Destination network address: hostname (e.g. 'localhost'), FQDN (e.g. 'elastic.co'), IPv4 (e.g. '127.0.0.1') or IPv6 (e.g. '::1')",
+                                    "maxLength": 1024
+                                },
+                                "port": {
+                                    "type": ["integer", "null"],
+                                    "description": "Destination network port (e.g. 443)"
+                                },
+                                "service": {
+                                    "description": "Destination service context",
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "type": {
+                                            "description": "Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type.",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        },
+                                        "name": {
+                                            "description": "Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq')",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        },
+                                        "resource": {
+                                            "description": "Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        }
+                                    },
+                                    "required": ["type", "name", "resource"]
+                                }
+                            }
+                        },
+                        "db": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data for database spans",
+                            "properties": {
+                                "instance": {
+                                    "type": ["string", "null"],
+                                    "description": "Database instance name"
+                                },
+                                "link": {
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024,
+                                    "description": "Database link"
+                                },
+                                "statement": {
+                                    "type": ["string", "null"],
+                                    "description": "A database statement (e.g. query) for the given database type"
+                                },
+                                "type": {
+                                    "type": ["string", "null"],
+                                    "description": "Database type. For any SQL database, \"sql\". For others, the lower-case database category, e.g. \"cassandra\", \"hbase\", or \"redis\""
+                                },
+                                "user": {
+                                    "type": ["string", "null"],
+                                    "description": "Username for accessing database"
+                                },
+                                "rows_affected": {
+                                    "type": ["integer", "null"],
+                                    "description": "Number of rows affected by the SQL statement (if applicable)"
+                                }
+                            }
+                        },
+                        "http": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data of the related http request.",
+                            "properties": {
+                                "url": {
+                                    "type": ["string", "null"],
+                                    "description": "The raw url of the correlating http request."
+                                },
+                                "status_code": {
+                                    "type": ["integer", "null"],
+                                    "description": "The status code of the http request."
+                                },
+                                "method": {
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024,
+                                    "description": "The method of the http request."
+                                }
+                            }
+                        },
+                        "tags": {
+                            "$ref": "../tags.json"
+                        },
+                        "service": {
+                            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+                            "properties": {
+                                "agent": {
+                                    "description": "Name and version of the Elastic APM agent",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "version": {
+                                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "ephemeral_id": {
+                                            "description": "Free format ID used for metrics correlation by some agents",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "description": "Immutable name of the service emitting this event",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                                    "maxLength": 1024
+                                }
+                            }
+                        },
+                        "message": {
+                            "$ref": "../message.json"
+                        }
+                    }
+                },
+                "duration": {
+                    "type": "number",
+                    "description": "Duration of the span in milliseconds"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Generic designation of a span in the scope of a transaction",
+                    "maxLength": 1024
+                },
+                "stacktrace": {
+                    "type": ["array", "null"],
+                    "description": "List of stack frames with variable attributes (eg: lineno, filename, etc)",
+                    "items": {
+                        "$ref": "../stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                },
+                "sync": {
+                    "type": ["boolean", "null"],
+                    "description": "Indicates whether the span was executed synchronously or asynchronously."
+                }
+            },
+            "required": ["duration", "name", "type", "id","trace_id", "parent_id"]
+        },
+        { "anyOf":[
+                {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}},
+                {"required": ["start"], "properties": {"start": { "type": "number" }}}
+            ]
+        }
+    ]
+}

--- a/schema/apm-7.6/docs/spec/stacktrace_frame.json
+++ b/schema/apm-7.6/docs/spec/stacktrace_frame.json
@@ -1,0 +1,69 @@
+{
+    "$id": "docs/spec/stacktrace_frame.json",
+    "title": "Stacktrace",
+    "type": "object",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
+    "properties": {
+        "abs_path": {
+            "description": "The absolute path of the file involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "colno": {
+            "description": "Column number",
+            "type": ["integer", "null"]
+        },
+        "context_line": {
+            "description": "The line of code part of the stack frame",
+            "type": ["string", "null"]
+        },
+        "filename": {
+            "description": "The relative filename of the code involved in the stack frame, used e.g. to do error checksumming",
+            "type": ["string", "null"]
+        },
+        "classname": {
+            "description": "The classname of the code involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "function": {
+            "description": "The function involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "library_frame": {
+            "description": "A boolean, indicating if this frame is from a library or user code",
+            "type": ["boolean", "null"]
+        },
+        "lineno": {
+            "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
+            "type": ["integer", "null"]
+        },
+        "module": {
+            "description": "The module to which frame belongs to",
+            "type": ["string", "null"]
+        },
+        "post_context": {
+            "description": "The lines of code after the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "pre_context": {
+            "description": "The lines of code before the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "vars": {
+            "description": "Local variables for this stack frame",
+            "type": ["object", "null"],
+            "properties": {}
+        }
+    },
+    "anyOf": [
+        { "required": ["filename"], "properties": {"filename": { "type": "string" }} },
+        { "required": ["classname"], "properties": {"classname": { "type": "string" }} }
+    ]
+}

--- a/schema/apm-7.6/docs/spec/system.json
+++ b/schema/apm-7.6/docs/spec/system.json
@@ -1,0 +1,74 @@
+{
+    "$id": "doc/spec/system.json",
+    "title": "System",
+    "type": ["object", "null"],
+    "properties": {
+        "architecture": {
+            "description": "Architecture of the system the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "hostname": {
+            "description": "Deprecated. Hostname of the system the agent is running on. Will be ignored if kubernetes information is set.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "detected_hostname": {
+            "description": "Hostname of the host the monitored service is running on. It normally contains what the hostname command returns on the host machine. Will be ignored if kubernetes information is set, otherwise should always be set.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "configured_hostname": {
+            "description": "Name of the host the monitored service is running on. It should only be set when configured by the user. If empty, will be set to detected_hostname or derived from kubernetes information if provided.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "platform": {
+            "description": "Name of the system platform the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "container": {
+            "properties": {
+                "id" : {
+                    "description": "Container ID",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            },
+            "required": ["id"]
+        },
+        "kubernetes": {
+            "properties": {
+                "namespace": {
+                    "description": "Kubernetes namespace",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "pod":{
+                    "properties": {
+                        "name": {
+                            "description": "Kubernetes pod name",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "uid": {
+                            "description": "Kubernetes pod uid",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "node":{
+                    "properties": {
+                        "name": {
+                            "description": "Kubernetes node name",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/tags.json
+++ b/schema/apm-7.6/docs/spec/tags.json
@@ -1,0 +1,13 @@
+{
+    "$id": "doc/spec/tags.json",
+    "title": "Tags",
+    "type": ["object", "null"],
+    "description": "A flat mapping of user-defined tags with string, boolean or number values.",
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["string", "boolean", "number", "null"],
+            "maxLength": 1024
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema/apm-7.6/docs/spec/timestamp_epoch.json
+++ b/schema/apm-7.6/docs/spec/timestamp_epoch.json
@@ -1,0 +1,12 @@
+{
+    "$id": "doc/spec/timestamp_epoch.json",
+    "title": "Timestamp Epoch",
+    "description": "Object with 'timestamp' property.",
+    "type": ["object"],
+    "properties": {  
+        "timestamp": {
+            "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
+            "type": ["integer", "null"]
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/timestamp_rfc3339.json
+++ b/schema/apm-7.6/docs/spec/timestamp_rfc3339.json
@@ -1,0 +1,14 @@
+{
+    "$id": "doc/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
+    "type": ["object"],
+    "properties": {
+        "timestamp": {
+            "type": ["string", "null"],
+            "pattern": "Z$",
+            "format": "date-time",
+            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/transaction_name.json
+++ b/schema/apm-7.6/docs/spec/transaction_name.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transaction_name.json",
+    "title": "Transaction Name",
+    "type": ["object"],
+    "properties": {
+        "name": {
+            "type": ["string","null"],
+            "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/transaction_type.json
+++ b/schema/apm-7.6/docs/spec/transaction_type.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transaction_type.json",
+    "title": "Transaction Type",
+    "type": ["object"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.6/docs/spec/transactions/mark.json
+++ b/schema/apm-7.6/docs/spec/transactions/mark.json
@@ -1,0 +1,11 @@
+{
+    "$id": "docs/spec/transactions/mark.json",
+    "type": ["object", "null"],
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["number", "null"]
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema/apm-7.6/docs/spec/transactions/transaction.json
+++ b/schema/apm-7.6/docs/spec/transactions/transaction.json
@@ -1,0 +1,72 @@
+{
+    "$id": "docs/spec/transactions/transaction.json",
+    "type": "object",
+    "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        { "$ref": "../transaction_name.json" },
+        { "$ref": "../transaction_type.json" },
+        {  
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Hex encoded 64 random bits ID of the transaction.", 
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.", 
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Only root transactions of a trace do not have a parent_id, otherwise it needs to be set.", 
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "span_count": {
+                    "type": "object",
+                    "properties": {
+                        "started": {
+                            "type": "integer",
+                            "description": "Number of correlated spans that are recorded."
+
+                        },
+                        "dropped": {
+                            "type": ["integer","null"],
+                            "description": "Number of spans that have been dropped by the agent recording the transaction."
+
+                        }
+                    },
+                    "required": ["started"]
+                },
+                "context": {
+                    "$ref": "../context.json"
+                },
+                "duration": {
+                    "type": "number",
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                },
+                "result": {
+                    "type": ["string", "null"],
+                    "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
+                    "maxLength": 1024
+                },
+                "marks": {
+                    "type": ["object", "null"],
+                    "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
+                    "patternProperties": {
+                        "^[^.*\"]*$": {
+                            "$ref": "mark.json"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "sampled": {
+                    "type": ["boolean", "null"],
+                    "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                }
+            },
+            "required": ["id", "trace_id", "span_count", "duration", "type"]
+        }
+    ]
+}

--- a/schema/apm-7.6/docs/spec/user.json
+++ b/schema/apm-7.6/docs/spec/user.json
@@ -1,0 +1,22 @@
+{
+    "$id": "docs/spec/user.json",
+    "title": "User",
+    "type": ["object", "null"],
+    "properties": {
+        "id": {
+            "description": "Identifier of the logged in user, e.g. the primary key of the user",
+            "type": ["string", "integer", "null"],
+            "maxLength": 1024
+        },
+        "email": {
+            "description": "Email of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "username": {
+            "description": "The username of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/cloud.json
+++ b/schema/apm-7.8/docs/spec/cloud.json
@@ -1,0 +1,74 @@
+{
+    "$id": "docs/spec/cloud.json",
+    "title": "Cloud",
+    "type": ["object", "null"],
+    "properties": {
+        "account": {
+            "properties": {
+                "id" : {
+                    "description": "Cloud account ID",
+                    "type": ["string"],
+                    "maxLength": 1024
+                },
+                "name" : {
+                    "description": "Cloud account name",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "availability_zone": {
+            "description": "Cloud availability zone name. e.g. us-east-1a",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "instance": {
+            "properties": {
+                "id" : {
+                    "description": "Cloud instance/machine ID",
+                    "type": ["string"],
+                    "maxLength": 1024
+                },
+                "name" : {
+                    "description": "Cloud instance/machine name",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "machine": {
+            "properties": {
+                "type" : {
+                    "description": "Cloud instance/machine type",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "project": {
+            "properties": {
+                "id" : {
+                    "description": "Cloud project ID",
+                    "type": ["string"],
+                    "maxLength": 1024
+                },
+                "name" : {
+                    "description": "Cloud project name",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "provider": {
+            "description": "Cloud provider name. e.g. aws, azure, gcp, digitalocean.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "region": {
+            "description": "Cloud region name. e.g. us-east-1",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    },
+    "required": ["provider"]
+}

--- a/schema/apm-7.8/docs/spec/context.json
+++ b/schema/apm-7.8/docs/spec/context.json
@@ -1,0 +1,70 @@
+{
+    "$id": "docs/spec/context.json",
+    "title": "Context",
+    "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
+    "type": ["object", "null"],
+    "properties": {
+        "custom": {
+            "description": "An arbitrary mapping of additional metadata to store with the event.",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "^[^.*\"]*$": {}
+            },
+            "additionalProperties": false
+        },
+        "response": {
+            "type": ["object", "null"],
+            "allOf": [
+                { "$ref": "./http_response.json" },
+                {
+                    "properties": {
+                        "finished": {
+                            "description": "A boolean indicating whether the response was finished or not",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "headers_sent": {
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "request": {
+            "$ref": "request.json"
+        },
+        "tags": {
+            "$ref": "tags.json"
+        },
+        "user": {
+            "description": "Describes the correlated user for this event. If user data are provided here, all user related information from metadata is ignored, otherwise the metadata's user information will be stored with the event.",
+            "$ref": "user.json"
+        },
+        "page": {
+            "description": "",
+            "type": ["object", "null"],
+            "properties": {
+                "referer": {
+                    "description": "RUM specific field that stores the URL of the page that 'linked' to the current page.",
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "description": "RUM specific field that stores the URL of the current page",
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "service": {
+            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+            "$ref": "service.json"
+        },
+        "message": {
+            "$ref": "message.json"
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/errors/error.json
+++ b/schema/apm-7.8/docs/spec/errors/error.json
@@ -1,0 +1,154 @@
+{
+    "$id": "docs/spec/errors/error.json",
+    "type": "object",
+    "description": "An error or a logged error message captured by an agent occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        {
+            "properties": {
+                "id": {
+                    "type": ["string"],
+                    "description": "Hex encoded 128 random bits ID of the error.",
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "transaction_id": {
+                    "type": ["string", "null"],
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction. Must be present if trace_id and parent_id are set.",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "transaction": {
+                    "type": ["object", "null"],
+                    "description": "Data for correlating errors with transactions",
+                    "properties": {
+                        "sampled": {
+                            "type": ["boolean", "null"],
+                            "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                        },
+                        "type": {
+                            "type": ["string", "null"],
+                            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "context": {
+                    "$ref": "./../context.json"
+                },
+                "culprit": {
+                    "description": "Function call which was the primary perpetrator of this event.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "exception": {
+                    "description": "Information about the originally thrown error.",
+                    "type": ["object", "null"],
+                    "properties": {
+                        "code": {
+                            "type": ["string", "integer", "null"],
+                            "maxLength": 1024,
+                            "description": "The error code set when the error happened, e.g. database error code."
+                        },
+                        "message": {
+                            "description": "The original error message.",
+                            "type": ["string", "null"]
+                        },
+                        "module": {
+                            "description": "Describes the exception type's module namespace.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "attributes": {
+                            "type": ["object", "null"]
+                        },
+                        "stacktrace": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "$ref": "./../stacktrace_frame.json"
+                            },
+                            "minItems": 0
+                        },
+                        "type": {
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "handled": {
+                            "type": ["boolean", "null"],
+                            "description": "Indicator whether the error was caught somewhere in the code or not."
+                        },
+                        "cause": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "type": ["object", "null"],
+                                "description": "Recursive exception object"
+                            },
+                            "minItems": 0,
+                            "description": "Exception tree"
+                        }
+                    },
+                    "anyOf": [
+                        {"required": ["message"], "properties": {"message": {"type": "string"}}},
+                        {"required": ["type"], "properties": {"type": {"type": "string"}}}
+                    ]
+                },
+                "log": {
+                    "type": ["object", "null"],
+                    "description": "Additional information added when logging the error.",
+                    "properties": {
+                        "level": {
+                            "description": "The severity of the record.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "logger_name": {
+                            "description": "The name of the logger instance used.",
+                            "type": ["string", "null"],
+                            "default": "default",
+                            "maxLength": 1024
+                        },
+                        "message": {
+                            "description": "The additionally logged error message.",
+                            "type": "string"
+                        },
+                        "param_message": {
+                            "description": "A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+
+                        },
+                        "stacktrace": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "$ref": "./../stacktrace_frame.json"
+                            },
+                            "minItems": 0
+                        }
+                    },
+                    "required": ["message"]
+                }
+            },
+            "allOf": [
+                { "required": ["id"] },
+                { "if": {"required": ["transaction_id"], "properties": {"transaction_id": { "type": "string" }}},
+                    "then": { "required": ["trace_id", "parent_id"], "properties": {"trace_id": { "type": "string" }, "parent_id": {"type": "string"}}}},
+                { "if": {"required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}},
+                    "then": { "required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}} },
+                { "if": {"required": ["parent_id"], "properties": {"parent_id": { "type": "string" }}},
+                    "then": { "required": ["trace_id"], "properties": {"trace_id": { "type": "string" }}} }
+            ],
+            "anyOf": [
+                { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
+                { "required": ["log"], "properties": {"log": { "type": "object" }} }
+            ]
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/errors/rum_v3_error.json
+++ b/schema/apm-7.8/docs/spec/errors/rum_v3_error.json
@@ -1,0 +1,154 @@
+{
+    "$id": "docs/spec/errors/rum_v3_error.json",
+    "type": "object",
+    "description": "An error or a logged error message captured by an agent occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        {
+            "properties": {
+                "id": {
+                    "type": ["string"],
+                    "description": "Hex encoded 128 random bits ID of the error.",
+                    "maxLength": 1024
+                },
+                "tid": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace. Must be present if transaction_id and parent_id are set.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "xid": {
+                    "type": ["string", "null"],
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction. Must be present if trace_id and parent_id are set.",
+                    "maxLength": 1024
+                },
+                "pid": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Must be present if trace_id and transaction_id are set.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "x": {
+                    "type": ["object", "null"],
+                    "description": "Data for correlating errors with transactions",
+                    "properties": {
+                        "sm": {
+                            "type": ["boolean", "null"],
+                            "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                        },
+                        "t": {
+                            "type": ["string", "null"],
+                            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "c": {
+                    "$ref": "./../rum_v3_context.json"
+                },
+                "cu": {
+                    "description": "Function call which was the primary perpetrator of this event.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "ex": {
+                    "description": "Information about the originally thrown error.",
+                    "type": ["object", "null"],
+                    "properties": {
+                        "cd": {
+                            "type": ["string", "integer", "null"],
+                            "maxLength": 1024,
+                            "description": "The error code set when the error happened, e.g. database error code."
+                        },
+                        "mg": {
+                            "description": "The original error message.",
+                            "type": ["string", "null"]
+                        },
+                        "mo": {
+                            "description": "Describes the exception type's module namespace.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "at": {
+                            "type": ["object", "null"]
+                        },
+                        "st": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "$ref": "./../rum_v3_stacktrace_frame.json"
+                            },
+                            "minItems": 0
+                        },
+                        "t": {
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "hd": {
+                            "type": ["boolean", "null"],
+                            "description": "Indicator whether the error was caught somewhere in the code or not."
+                        },
+                        "ca": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "type": ["object", "null"],
+                                "description": "Recursive exception object"
+                            },
+                            "minItems": 0,
+                            "description": "Exception tree"
+                        }
+                    },
+                    "anyOf": [
+                        {"required": ["mg"], "properties": {"mg": {"type": "string"}}},
+                        {"required": ["t"], "properties": {"t": {"type": "string"}}}
+                    ]
+                },
+                "log": {
+                    "type": ["object", "null"],
+                    "description": "Additional information added when logging the error.",
+                    "properties": {
+                        "lv": {
+                            "description": "The severity of the record.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "ln": {
+                            "description": "The name of the logger instance used.",
+                            "type": ["string", "null"],
+                            "default": "default",
+                            "maxLength": 1024
+                        },
+                        "mg": {
+                            "description": "The additionally logged error message.",
+                            "type": "string"
+                        },
+                        "pmg": {
+                            "description": "A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+
+                        },
+                        "st": {
+                            "type": ["array", "null"],
+                            "items": {
+                                "$ref": "./../rum_v3_stacktrace_frame.json"
+                            },
+                            "minItems": 0
+                        }
+                    },
+                    "required": ["mg"]
+                }
+            },
+            "allOf": [
+                { "required": ["id"] },
+                { "if": {"required": ["xid"], "properties": {"xid": { "type": "string" }}},
+                    "then": { "required": ["tid", "pid"], "properties": {"tid": { "type": "string" }, "pid": {"type": "string"}}}},
+                { "if": {"required": ["tid"], "properties": {"tid": { "type": "string" }}},
+                    "then": { "required": ["pid"], "properties": {"pid": { "type": "string" }}} },
+                { "if": {"required": ["pid"], "properties": {"pid": { "type": "string" }}},
+                    "then": { "required": ["tid"], "properties": {"tid": { "type": "string" }}} }
+            ],
+            "anyOf": [
+                { "required": ["ex"], "properties": {"ex": { "type": "object" }} },
+                { "required": ["log"], "properties": {"log": { "type": "object" }} }
+            ]
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/http_response.json
+++ b/schema/apm-7.8/docs/spec/http_response.json
@@ -1,0 +1,35 @@
+{
+    "$id": "docs/spec/http_response.json",
+    "title": "HTTP response object",
+    "description": "HTTP response object, used by error, span and transction documents",
+    "type": ["object", "null"],
+    "properties": {
+        "status_code": {
+            "type": ["integer", "null"],
+            "description": "The status code of the http request."
+        },
+        "transfer_size": {
+            "type": ["number", "null"],
+            "description": "Total size of the payload."
+        },
+        "encoded_body_size": {
+            "type": ["number", "null"],
+            "description": "The encoded size of the payload."
+        },
+        "decoded_body_size":  {
+            "type": ["number", "null"],
+            "description": "The decoded size of the payload."
+        },
+        "headers": {
+            "type": ["object", "null"],
+            "patternProperties": {
+                "[.*]*$": {
+                    "type": ["string", "array", "null"],
+                    "items": {
+                        "type": ["string"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/message.json
+++ b/schema/apm-7.8/docs/spec/message.json
@@ -1,0 +1,43 @@
+{
+    "$id": "docs/spec/message.json",
+    "title": "Message",
+    "description": "Details related to message receiving and publishing if the captured event integrates with a messaging system",
+    "type": ["object", "null"],
+    "properties": {
+        "queue": {
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "description": "Name of the message queue where the message is received.",
+                    "type": ["string","null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "age": {
+            "type": ["object", "null"],
+            "properties": {
+                "ms": {
+                    "description": "The age of the message in milliseconds. If the instrumented messaging framework provides a timestamp for the message, agents may use it. Otherwise, the sending agent can add a timestamp in milliseconds since the Unix epoch to the message's metadata to be retrieved by the receiving agent. If a timestamp is not available, agents should omit this field.",
+                    "type": ["integer", "null"]
+                }
+            }
+        },
+        "body": {
+            "description": "messsage body, similar to an http request body",
+            "type": ["string", "null"]
+        },
+        "headers": {
+            "description": "messsage headers, similar to http request headers",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "[.*]*$": {
+                    "type": ["string", "array", "null"],
+                    "items": {
+                        "type": ["string"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/metadata.json
+++ b/schema/apm-7.8/docs/spec/metadata.json
@@ -1,0 +1,40 @@
+{
+    "$id": "docs/spec/metadata.json",
+    "title": "Metadata",
+    "description": "Metadata concerning the other objects in the stream.",
+    "type": ["object"],
+    "properties": {
+        "service": {
+            "$ref": "service.json",
+            "type": "object",
+            "required": ["name", "agent"],
+            "properties.name.type": "string",
+            "properties.agent.type": "string",
+            "properties.agent.required": ["name", "version"],
+            "properties.agent.properties.name.type": "string",
+            "properties.agent.properties.version.type": "string",
+            "properties.runtime.required": ["name", "version"],
+            "properties.runtime.properties.name.type": "string",
+            "properties.runtime.properties.version.type": "string",
+            "properties.language.required": ["name"],
+            "properties.language.properties.name.type": "string"
+        },
+        "process": {
+            "$ref": "process.json"
+        },
+        "system": {
+            "$ref": "system.json"
+        },
+        "user": {
+            "description": "Describes the authenticated User for a request.",
+            "$ref": "user.json"
+        },
+	"cloud": {
+            "$ref": "cloud.json"
+	},
+        "labels": {
+            "$ref": "tags.json"
+        }
+    },
+    "required": ["service"]
+}

--- a/schema/apm-7.8/docs/spec/metricsets/metricset.json
+++ b/schema/apm-7.8/docs/spec/metricsets/metricset.json
@@ -1,0 +1,32 @@
+{
+    "$id": "docs/spec/metricsets/metricset.json",
+    "type": "object",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json"},
+        { "$ref": "../span_type.json" },
+        { "$ref": "../span_subtype.json" },
+        { "$ref": "../transaction_name.json" },
+        { "$ref": "../transaction_type.json" },
+        {
+            "properties": {
+                "samples": {
+                    "type": [
+                        "object"
+                    ],
+                    "description": "Sampled application metrics collected from the agent.",
+                    "patternProperties": {
+                        "^[^*\"]*$": {
+                            "$ref": "sample.json"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "tags": {
+                    "$ref": "../tags.json"
+                }
+            },
+            "required": ["samples"]
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/metricsets/rum_v3_metricset.json
+++ b/schema/apm-7.8/docs/spec/metricsets/rum_v3_metricset.json
@@ -1,0 +1,52 @@
+{
+    "$id": "docs/spec/metricsets/rum_v3_metricset.json",
+    "description": "Data captured by an agent representing an event occurring in a monitored service",
+    "properties": {
+        "y": {
+            "type": ["object", "null"],
+            "description": "span",
+            "properties": {
+                "t": {
+                    "type": "string",
+                    "description": "type",
+                    "maxLength": 1024
+                },
+                "su": {
+                    "type": ["string", "null"],
+                    "description": "subtype",
+                    "maxLength": 1024
+                }
+            }
+        },
+        "sa": {
+            "type": "object",
+            "description": "Sampled application metrics collected from the agent.",
+            "properties": {
+                "xdc": {
+                    "description": "transaction.duration.count",
+                    "$ref": "rum_v3_sample.json"
+                },
+                "xds": {
+                    "description": "transaction.duration.sum.us",
+                    "$ref": "rum_v3_sample.json"
+                },
+                "xbc": {
+                    "description": "transaction.breakdown.count",
+                    "$ref": "rum_v3_sample.json"
+                },
+                "ysc": {
+                    "description": "span.self_time.count",
+                    "$ref": "rum_v3_sample.json"
+                },
+                "yss": {
+                    "description": "span.self_time.sum.us",
+                    "$ref": "rum_v3_sample.json"
+                }
+            }
+        },
+        "tags": {
+            "$ref": "../tags.json"
+        }
+    },
+    "required": ["sa"]
+}

--- a/schema/apm-7.8/docs/spec/metricsets/rum_v3_sample.json
+++ b/schema/apm-7.8/docs/spec/metricsets/rum_v3_sample.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metricsets/rum_v3_sample.json",
+    "type": ["object", "null"],
+    "description": "A single metric sample.",
+    "properties": {
+        "v": {"type": "number"}
+    },
+    "required": ["v"]
+}

--- a/schema/apm-7.8/docs/spec/metricsets/sample.json
+++ b/schema/apm-7.8/docs/spec/metricsets/sample.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "docs/spec/metricsets/sample.json",
+    "type": ["object", "null"],
+    "description": "A single metric sample.",
+    "properties": {
+        "value": {"type": "number"}
+    },
+    "required": ["value"]
+}

--- a/schema/apm-7.8/docs/spec/process.json
+++ b/schema/apm-7.8/docs/spec/process.json
@@ -1,0 +1,28 @@
+{
+  "$id": "docs/spec/process.json",
+  "title": "Process",
+  "type": ["object", "null"],
+  "properties": {
+      "pid": {
+          "description": "Process ID of the service",
+          "type": ["integer"]
+      },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["integer", "null"]
+      },
+      "title": {
+          "type": ["string", "null"],
+          "maxLength": 1024
+      },
+      "argv": {
+        "description": "Command line arguments used to start this process",
+        "type": ["array", "null"],
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
+    }
+  },
+  "required": ["pid"]
+}

--- a/schema/apm-7.8/docs/spec/request.json
+++ b/schema/apm-7.8/docs/spec/request.json
@@ -1,0 +1,103 @@
+{
+    "$id": "docs/spec/request.json",
+    "title": "Request",
+    "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
+    "type": ["object", "null"],
+    "properties": {
+        "body": {
+            "description": "Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.",
+            "type": ["object", "string", "null"]
+        },
+        "env": {
+            "description": "The env variable is a compounded of environment information passed from the webserver.",
+            "type": ["object", "null"],
+            "properties": {}
+        },
+        "headers": {
+            "description": "Should include any headers sent by the requester. Cookies will be taken by headers if supplied.",
+            "type": ["object", "null"],
+            "patternProperties": {
+                "[.*]*$": {
+                    "type": ["string", "array", "null"],
+                    "items": {
+                        "type": ["string"]
+                    }
+                }
+            }
+        },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "method": {
+            "description": "HTTP method.",
+            "type": "string",
+            "maxLength": 1024
+        },
+        "socket": {
+            "type": ["object", "null"],
+            "properties": {
+                "encrypted": {
+                    "description": "Indicates whether request was sent as SSL/HTTPS request.",
+                    "type": ["boolean", "null"]
+                },
+                "remote_address": {
+                    "description": "The network address sending the request. Should be obtained through standard APIs and not parsed from any headers like 'Forwarded'.",
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "url": {
+            "description": "A complete Url, with scheme, host and path.",
+            "type": "object",
+            "properties": {
+                "raw": {
+                    "type": ["string", "null"],
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
+                    "maxLength": 1024
+                },
+                "protocol": {
+                    "type": ["string", "null"],
+                    "description": "The protocol of the request, e.g. 'https:'.",
+                    "maxLength": 1024
+                },
+                "full": {
+                    "type": ["string", "null"],
+                    "description": "The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "maxLength": 1024
+                },
+                "hostname": {
+                    "type": ["string", "null"],
+                    "description": "The hostname of the request, e.g. 'example.com'.",
+                    "maxLength": 1024
+                },
+                "port": {
+                    "type": ["string", "integer","null"],
+                    "description": "The port of the request, e.g. '443'",
+                    "maxLength": 1024
+                },
+                "pathname": {
+                    "type": ["string", "null"],
+                    "description": "The path of the request, e.g. '/search'",
+                    "maxLength": 1024
+                },
+                "search": {
+                    "description": "The search describes the query string of the request. It is expected to have values delimited by ampersands.",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "hash": {
+                    "type": ["string", "null"],
+                    "description": "The hash of the request URL, e.g. 'top'",
+                    "maxLength": 1024
+                }
+            }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
+        }
+    },
+    "required": ["url", "method"]
+}

--- a/schema/apm-7.8/docs/spec/rum_v3_context.json
+++ b/schema/apm-7.8/docs/spec/rum_v3_context.json
@@ -1,0 +1,164 @@
+{
+    "$id": "docs/spec/rum_v3_context.json",
+    "title": "Context",
+    "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
+    "type": [
+        "object",
+        "null"
+    ],
+    "properties": {
+        "cu": {
+            "description": "An arbitrary mapping of additional metadata to store with the event.",
+            "type": [
+                "object",
+                "null"
+            ],
+            "patternProperties": {
+                "^[^.*\"]*$": {}
+            },
+            "additionalProperties": false
+        },
+        "r": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "allOf": [
+                {
+                    "properties": {
+                        "sc": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "description": "The status code of the http request."
+                        },
+                        "ts": {
+                            "type": [
+                                "number",
+                                "null"
+                            ],
+                            "description": "Total size of the payload."
+                        },
+                        "ebs": {
+                            "type": [
+                                "number",
+                                "null"
+                            ],
+                            "description": "The encoded size of the payload."
+                        },
+                        "dbs": {
+                            "type": [
+                                "number",
+                                "null"
+                            ],
+                            "description": "The decoded size of the payload."
+                        },
+                        "he": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "patternProperties": {
+                                "[.*]*$": {
+                                    "type": [
+                                        "string",
+                                        "array",
+                                        "null"
+                                    ],
+                                    "items": {
+                                        "type": [
+                                            "string"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "q": {
+            "properties": {
+                "en": {
+                    "description": "The env variable is a compounded of environment information passed from the webserver.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {}
+                },
+                "he": {
+                    "description": "Should include any headers sent by the requester. Cookies will be taken by headers if supplied.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "patternProperties": {
+                        "[.*]*$": {
+                            "type": [
+                                "string",
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": [
+                                    "string"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "hve": {
+                    "description": "HTTP version.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "mt": {
+                    "description": "HTTP method.",
+                    "type": "string",
+                    "maxLength": 1024
+                }
+            },
+            "required": [
+                "mt"
+            ]
+        },
+        "g": {
+            "$ref": "tags.json"
+        },
+        "u": {
+            "$ref": "rum_v3_user.json"
+        },
+        "p": {
+            "description": "",
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "rf": {
+                    "description": "RUM specific field that stores the URL of the page that 'linked' to the current page.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "url": {
+                    "description": "RUM specific field that stores the URL of the current page",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "se": {
+            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+            "$ref": "rum_v3_service.json"
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/rum_v3_metadata.json
+++ b/schema/apm-7.8/docs/spec/rum_v3_metadata.json
@@ -1,0 +1,45 @@
+{
+    "$id": "docs/spec/rum_v3_metadata.json",
+    "title": "Metadata",
+    "description": "Metadata concerning the other objects in the stream.",
+    "type": [
+        "object"
+    ],
+    "properties": {
+        "se": {
+            "$ref": "rum_v3_service.json",
+            "type": "object",
+            "required": [
+                "n",
+                "a"
+            ],
+            "properties.n.type": "string",
+            "properties.a.type": "string",
+            "properties.a.required": [
+                "n",
+                "ve"
+            ],
+            "properties.a.properties.n.type": "string",
+            "properties.a.properties.ve.type": "string",
+            "properties.ru.required": [
+                "n",
+                "ve"
+            ],
+            "properties.ru.properties.n.type": "string",
+            "properties.ru.properties.ve.type": "string",
+            "properties.la.required": [
+                "n"
+            ],
+            "properties.la.properties.n.type": "string"
+        },
+        "u": {
+            "$ref": "rum_v3_user.json"
+        },
+        "l": {
+            "$ref": "tags.json"
+        }
+    },
+    "required": [
+        "se"
+    ]
+}

--- a/schema/apm-7.8/docs/spec/rum_v3_service.json
+++ b/schema/apm-7.8/docs/spec/rum_v3_service.json
@@ -1,0 +1,129 @@
+{
+    "$id": "docs/spec/rum_v3_service.json",
+    "title": "Service",
+    "type": [
+        "object",
+        "null"
+    ],
+    "properties": {
+        "a": {
+            "description": "Name and version of the Elastic APM agent",
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "n": {
+                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "ve": {
+                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "fw": {
+            "description": "Name and version of the web framework used",
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "n": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "ve": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "la": {
+            "description": "Name and version of the programming language used",
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "n": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "ve": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "n": {
+            "description": "Immutable name of the service emitting this event",
+            "type": [
+                "string",
+                "null"
+            ],
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024
+        },
+        "en": {
+            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 1024
+        },
+        "ru": {
+            "description": "Name and version of the language runtime running this service",
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "n": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "ve": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "ve": {
+            "description": "Version of the service emitting this event",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/rum_v3_stacktrace_frame.json
+++ b/schema/apm-7.8/docs/spec/rum_v3_stacktrace_frame.json
@@ -1,0 +1,89 @@
+{
+    "$id": "docs/spec/rum_v3_stacktrace_frame.json",
+    "title": "Stacktrace",
+    "type": "object",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
+    "properties": {
+        "ap": {
+            "description": "The absolute path of the file involved in the stack frame",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "co": {
+            "description": "Column number",
+            "type": [
+                "integer",
+                "null"
+            ]
+        },
+        "cli": {
+            "description": "The line of code part of the stack frame",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "f": {
+            "description": "The relative filename of the code involved in the stack frame, used e.g. to do error checksumming",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "cn": {
+            "description": "The classname of the code involved in the stack frame",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "fn": {
+            "description": "The function involved in the stack frame",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "li": {
+            "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
+            "type": [
+                "integer",
+                "null"
+            ]
+        },
+        "mo": {
+            "description": "The module to which frame belongs to",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "poc": {
+            "description": "The lines of code after the stack frame",
+            "type": [
+                "array",
+                "null"
+            ],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "prc": {
+            "description": "The lines of code before the stack frame",
+            "type": [
+                "array",
+                "null"
+            ],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "f"
+    ]
+}

--- a/schema/apm-7.8/docs/spec/rum_v3_user.json
+++ b/schema/apm-7.8/docs/spec/rum_v3_user.json
@@ -1,0 +1,35 @@
+{
+    "$id": "docs/spec/rum_v3_user.json",
+    "title": "User",
+    "type": [
+        "object",
+        "null"
+    ],
+    "properties": {
+        "id": {
+            "description": "Identifier of the logged in user, e.g. the primary key of the user",
+            "type": [
+                "string",
+                "integer",
+                "null"
+            ],
+            "maxLength": 1024
+        },
+        "em": {
+            "description": "Email of the logged in user",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 1024
+        },
+        "un": {
+            "description": "The username of the logged in user",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/service.json
+++ b/schema/apm-7.8/docs/spec/service.json
@@ -1,0 +1,96 @@
+{
+    "$id": "docs/spec/service.json",
+    "title": "Service",
+    "type": ["object", "null"],
+    "properties": {
+        "agent": {
+            "description": "Name and version of the Elastic APM agent",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "ephemeral_id": {
+                    "description": "Free format ID used for metrics correlation by some agents",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "framework": {
+            "description": "Name and version of the web framework used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "language": {
+            "description": "Name and version of the programming language used",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": ["string", "null"],
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024
+        },
+        "environment": {
+            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "runtime": {
+            "description": "Name and version of the language runtime running this service",
+            "type": ["object", "null"],
+            "properties": {
+                "name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "version": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        },
+        "version": {
+            "description": "Version of the service emitting this event",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "node": {
+            "description": "Unique meaningful name of the service node.",
+            "type": ["object", "null"],
+            "properties": {
+                "configured_name": {
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/sourcemaps/payload.json
+++ b/schema/apm-7.8/docs/spec/sourcemaps/payload.json
@@ -1,0 +1,28 @@
+{
+    "$id": "docs/spec/sourcemaps/sourcemap-metadata.json",
+    "title": "Sourcemap Metadata",
+    "description": "Sourcemap Metadata",
+    "type": "object",
+    "properties": {
+        "bundle_filepath": {
+            "description": "relative path of the minified bundle file",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_version": {
+            "description": "Version of the service emitting this event",
+            "type": "string",
+            "maxLength": 1024,
+            "minLength": 1
+        },
+        "service_name": {
+            "description": "Immutable name of the service emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024,
+            "minLength": 1
+        }
+    },
+    "required": ["bundle_filepath", "service_name", "service_version"]
+}

--- a/schema/apm-7.8/docs/spec/span_subtype.json
+++ b/schema/apm-7.8/docs/spec/span_subtype.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/span_subtype.json",
+    "title": "Span Subtype",
+    "type": ["object"],
+    "properties": {
+        "subtype": {
+            "type": ["string", "null"],
+            "description": "A further sub-division of the type (e.g. postgresql, elasticsearch)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/span_type.json
+++ b/schema/apm-7.8/docs/spec/span_type.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/span_type.json",
+    "title": "Span Type",
+    "type": ["object"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/spans/rum_v3_span.json
+++ b/schema/apm-7.8/docs/spec/spans/rum_v3_span.json
@@ -1,0 +1,236 @@
+{
+    "$id": "docs/spec/spans/rum_v3_span.json",
+    "description": "An event captured by an agent occurring in a monitored service",
+    "allOf": [
+        {
+            "properties": {
+                "id": {
+                    "description": "Hex encoded 64 random bits ID of the span.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "pi": {
+                    "description": "Index of the parent span in the list. Absent when the parent is a transaction.",
+                    "type": ["integer", "null"],
+                    "maxLength": 1024
+                },
+                "s": {
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
+                },
+                "t": {
+                    "type": "string",
+                    "description": "Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)",
+                    "maxLength": 1024
+                },
+                "su": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "A further sub-division of the type (e.g. postgresql, elasticsearch)",
+                    "maxLength": 1024
+                },
+                "ac": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The specific kind of event within the sub-type represented by the span (e.g. query, connect)",
+                    "maxLength": 1024
+                },
+                "c": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "description": "Any other arbitrary data captured by the agent, optionally provided by the user",
+                    "properties": {
+                        "dt": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "description": "An object containing contextual data about the destination for spans",
+                            "properties": {
+                                "ad": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "Destination network address: hostname (e.g. 'localhost'), FQDN (e.g. 'elastic.co'), IPv4 (e.g. '127.0.0.1') or IPv6 (e.g. '::1')",
+                                    "maxLength": 1024
+                                },
+                                "po": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
+                                    "description": "Destination network port (e.g. 443)"
+                                },
+                                "se": {
+                                    "description": "Destination service context",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "t": {
+                                            "description": "Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type.",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "n": {
+                                            "description": "Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq')",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "rc": {
+                                            "description": "Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        }
+                                    },
+                                    "required": [
+                                        "t",
+                                        "n",
+                                        "rc"
+                                    ]
+                                }
+                            }
+                        },
+                        "h": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "description": "An object containing contextual data of the related http request.",
+                            "properties": {
+                                "url": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "The raw url of the correlating http request."
+                                },
+                                "sc": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
+                                    "description": "The status code of the http request."
+                                },
+                                "mt": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "maxLength": 1024,
+                                    "description": "The method of the http request."
+                                }
+                            }
+                        },
+                        "g": {
+                            "$ref": "../tags.json"
+                        },
+                        "se": {
+                            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+                            "properties": {
+                                "a": {
+                                    "description": "Name and version of the Elastic APM agent",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "n": {
+                                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "ve": {
+                                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        }
+                                    }
+                                },
+                                "n": {
+                                    "description": "Immutable name of the service emitting this event",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                                    "maxLength": 1024
+                                }
+                            }
+                        }
+                    }
+                },
+                "d": {
+                    "type": "number",
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
+                },
+                "n": {
+                    "type": "string",
+                    "description": "Generic designation of a span in the scope of a transaction",
+                    "maxLength": 1024
+                },
+                "st": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "description": "List of stack frames with variable attributes (eg: lineno, filename, etc)",
+                    "items": {
+                        "$ref": "../rum_v3_stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                },
+                "sy": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "description": "Indicates whether the span was executed synchronously or asynchronously."
+                }
+            },
+            "required": [
+                "d",
+                "n",
+                "t",
+                "id"
+            ]
+        },
+        {
+            "required": [
+                "s"
+            ],
+            "properties": {
+                "s": {
+                    "type": "number"
+                }
+            }
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/spans/span.json
+++ b/schema/apm-7.8/docs/spec/spans/span.json
@@ -1,0 +1,227 @@
+{
+    "$id": "docs/spec/spans/span.json",
+    "type": "object",
+    "description": "An event captured by an agent occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        { "$ref": "../span_type.json" },
+        { "$ref": "../span_subtype.json" },
+        {
+            "properties": {
+                "id": {
+                    "description": "Hex encoded 64 random bits ID of the span.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "transaction_id": {
+                    "type": ["string", "null"],
+                    "description": "Hex encoded 64 random bits ID of the correlated transaction.",
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "child_ids": {
+                    "description": "List of successor transactions and/or spans.",
+                    "type": ["array", "null"],
+                    "minItems": 0,
+                    "maxLength": 1024,
+                    "items": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "start": {
+                    "type": ["number", "null"],
+                    "description": "Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds"
+                },
+                "action": {
+                    "type": ["string", "null"],
+                    "description": "The specific kind of event within the sub-type represented by the span (e.g. query, connect)",
+                    "maxLength": 1024
+                },
+                "context": {
+                    "type": ["object", "null"],
+                    "description": "Any other arbitrary data captured by the agent, optionally provided by the user",
+                    "properties": {
+                        "destination": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data about the destination for spans",
+                            "properties": {
+                                "address": {
+                                    "type": ["string", "null"],
+                                    "description": "Destination network address: hostname (e.g. 'localhost'), FQDN (e.g. 'elastic.co'), IPv4 (e.g. '127.0.0.1') or IPv6 (e.g. '::1')",
+                                    "maxLength": 1024
+                                },
+                                "port": {
+                                    "type": ["integer", "null"],
+                                    "description": "Destination network port (e.g. 443)"
+                                },
+                                "service": {
+                                    "description": "Destination service context",
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                        "type": {
+                                            "description": "Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type.",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        },
+                                        "name": {
+                                            "description": "Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq')",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        },
+                                        "resource": {
+                                            "description": "Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        }
+                                    },
+                                    "required": ["type", "name", "resource"]
+                                }
+                            }
+                        },
+                        "db": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data for database spans",
+                            "properties": {
+                                "instance": {
+                                    "type": ["string", "null"],
+                                    "description": "Database instance name"
+                                },
+                                "link": {
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024,
+                                    "description": "Database link"
+                                },
+                                "statement": {
+                                    "type": ["string", "null"],
+                                    "description": "A database statement (e.g. query) for the given database type"
+                                },
+                                "type": {
+                                    "type": ["string", "null"],
+                                    "description": "Database type. For any SQL database, \"sql\". For others, the lower-case database category, e.g. \"cassandra\", \"hbase\", or \"redis\""
+                                },
+                                "user": {
+                                    "type": ["string", "null"],
+                                    "description": "Username for accessing database"
+                                },
+                                "rows_affected": {
+                                    "type": ["integer", "null"],
+                                    "description": "Number of rows affected by the SQL statement (if applicable)"
+                                }
+                            }
+                        },
+                        "http": {
+                            "type": ["object", "null"],
+                            "description": "An object containing contextual data of the related http request.",
+                            "properties": {
+                                "url": {
+                                    "type": ["string", "null"],
+                                    "description": "The raw url of the correlating http request."
+                                },
+                                "status_code": {
+                                    "type": ["integer", "null"],
+                                    "description": "Deprecated: Use span.context.http.response.status_code instead."
+                                },
+                                "method": {
+                                    "type": ["string", "null"],
+                                    "maxLength": 1024,
+                                    "description": "The method of the http request."
+                                },
+                                "response": {
+                                    "$ref": "../http_response.json"
+                                }
+                            }
+                        },
+                        "tags": {
+                            "$ref": "../tags.json"
+                        },
+                        "service": {
+                            "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+                            "properties": {
+                                "agent": {
+                                    "description": "Name and version of the Elastic APM agent",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "version": {
+                                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "maxLength": 1024
+                                        },
+                                        "ephemeral_id": {
+                                            "description": "Free format ID used for metrics correlation by some agents",
+                                            "type": ["string", "null"],
+                                            "maxLength": 1024
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "description": "Immutable name of the service emitting this event",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                                    "maxLength": 1024
+                                }
+                            }
+                        },
+                        "message": {
+                            "$ref": "../message.json"
+                        }
+                    }
+                },
+                "duration": {
+                    "type": "number",
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Generic designation of a span in the scope of a transaction",
+                    "maxLength": 1024
+                },
+                "stacktrace": {
+                    "type": ["array", "null"],
+                    "description": "List of stack frames with variable attributes (eg: lineno, filename, etc)",
+                    "items": {
+                        "$ref": "../stacktrace_frame.json"
+                    },
+                    "minItems": 0
+                },
+                "sync": {
+                    "type": ["boolean", "null"],
+                    "description": "Indicates whether the span was executed synchronously or asynchronously."
+                }
+            },
+            "required": ["duration", "name", "type", "id","trace_id", "parent_id"]
+        },
+        { "anyOf":[
+                {"required": ["timestamp"], "properties": {"timestamp": { "type": "integer" }}},
+                {"required": ["start"], "properties": {"start": { "type": "number" }}}
+            ]
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/stacktrace_frame.json
+++ b/schema/apm-7.8/docs/spec/stacktrace_frame.json
@@ -1,0 +1,69 @@
+{
+    "$id": "docs/spec/stacktrace_frame.json",
+    "title": "Stacktrace",
+    "type": "object",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
+    "properties": {
+        "abs_path": {
+            "description": "The absolute path of the file involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "colno": {
+            "description": "Column number",
+            "type": ["integer", "null"]
+        },
+        "context_line": {
+            "description": "The line of code part of the stack frame",
+            "type": ["string", "null"]
+        },
+        "filename": {
+            "description": "The relative filename of the code involved in the stack frame, used e.g. to do error checksumming",
+            "type": ["string", "null"]
+        },
+        "classname": {
+            "description": "The classname of the code involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "function": {
+            "description": "The function involved in the stack frame",
+            "type": ["string", "null"]
+        },
+        "library_frame": {
+            "description": "A boolean, indicating if this frame is from a library or user code",
+            "type": ["boolean", "null"]
+        },
+        "lineno": {
+            "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
+            "type": ["integer", "null"]
+        },
+        "module": {
+            "description": "The module to which frame belongs to",
+            "type": ["string", "null"]
+        },
+        "post_context": {
+            "description": "The lines of code after the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "pre_context": {
+            "description": "The lines of code before the stack frame",
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
+        },
+        "vars": {
+            "description": "Local variables for this stack frame",
+            "type": ["object", "null"],
+            "properties": {}
+        }
+    },
+    "anyOf": [
+        { "required": ["filename"], "properties": {"filename": { "type": "string" }} },
+        { "required": ["classname"], "properties": {"classname": { "type": "string" }} }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/system.json
+++ b/schema/apm-7.8/docs/spec/system.json
@@ -1,0 +1,74 @@
+{
+    "$id": "docs/spec/system.json",
+    "title": "System",
+    "type": ["object", "null"],
+    "properties": {
+        "architecture": {
+            "description": "Architecture of the system the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "hostname": {
+            "description": "Deprecated. Hostname of the system the agent is running on. Will be ignored if kubernetes information is set.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "detected_hostname": {
+            "description": "Hostname of the host the monitored service is running on. It normally contains what the hostname command returns on the host machine. Will be ignored if kubernetes information is set, otherwise should always be set.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "configured_hostname": {
+            "description": "Name of the host the monitored service is running on. It should only be set when configured by the user. If empty, will be set to detected_hostname or derived from kubernetes information if provided.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "platform": {
+            "description": "Name of the system platform the agent is running on.",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "container": {
+            "properties": {
+                "id" : {
+                    "description": "Container ID",
+                    "type": ["string"],
+                    "maxLength": 1024
+                }
+            },
+            "required": ["id"]
+        },
+        "kubernetes": {
+            "properties": {
+                "namespace": {
+                    "description": "Kubernetes namespace",
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "pod":{
+                    "properties": {
+                        "name": {
+                            "description": "Kubernetes pod name",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        },
+                        "uid": {
+                            "description": "Kubernetes pod uid",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "node":{
+                    "properties": {
+                        "name": {
+                            "description": "Kubernetes node name",
+                            "type": ["string", "null"],
+                            "maxLength": 1024
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/tags.json
+++ b/schema/apm-7.8/docs/spec/tags.json
@@ -1,0 +1,13 @@
+{
+    "$id": "docs/spec/tags.json",
+    "title": "Tags",
+    "type": ["object", "null"],
+    "description": "A flat mapping of user-defined tags with string, boolean or number values.",
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["string", "boolean", "number", "null"],
+            "maxLength": 1024
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema/apm-7.8/docs/spec/timestamp_epoch.json
+++ b/schema/apm-7.8/docs/spec/timestamp_epoch.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/timestamp_epoch.json",
+    "title": "Timestamp Epoch",
+    "description": "Object with 'timestamp' property.",
+    "type": ["object"],
+    "properties": {
+        "timestamp": {
+            "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
+            "type": ["integer", "null"]
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/timestamp_rfc3339.json
+++ b/schema/apm-7.8/docs/spec/timestamp_rfc3339.json
@@ -1,0 +1,14 @@
+{
+    "$id": "docs/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
+    "type": ["object"],
+    "properties": {
+        "timestamp": {
+            "type": ["string", "null"],
+            "pattern": "Z$",
+            "format": "date-time",
+            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/transaction_name.json
+++ b/schema/apm-7.8/docs/spec/transaction_name.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transaction_name.json",
+    "title": "Transaction Name",
+    "type": ["object"],
+    "properties": {
+        "name": {
+            "type": ["string","null"],
+            "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/transaction_type.json
+++ b/schema/apm-7.8/docs/spec/transaction_type.json
@@ -1,0 +1,12 @@
+{
+    "$id": "docs/spec/transaction_type.json",
+    "title": "Transaction Type",
+    "type": ["object"],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+            "maxLength": 1024
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/transactions/mark.json
+++ b/schema/apm-7.8/docs/spec/transactions/mark.json
@@ -1,0 +1,11 @@
+{
+    "$id": "docs/spec/transactions/mark.json",
+    "type": ["object", "null"],
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
+    "patternProperties": {
+        "^[^.*\"]*$": {
+            "type": ["number", "null"]
+        }
+    },
+    "additionalProperties": false
+}

--- a/schema/apm-7.8/docs/spec/transactions/rum_v3_mark.json
+++ b/schema/apm-7.8/docs/spec/transactions/rum_v3_mark.json
@@ -1,0 +1,107 @@
+{
+    "$id": "docs/spec/transactions/rum_v3_mark.json",
+    "type": ["object", "null"],
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
+    "properties": {
+        "a": {
+            "type": ["object", "null"],
+            "description": "agent",
+            "properties": {
+                "dc": {
+                    "type": ["number", "null"],
+                    "description": "domComplete"
+                },
+                "di": {
+                    "type": ["number", "null"],
+                    "description": "domInteractive"
+                },
+                "ds": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventStart"
+                },
+                "de": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventEnd"
+                },
+                "fb": {
+                    "type": ["number", "null"],
+                    "description": "timeToFirstByte"
+                },
+                "fp": {
+                    "type": ["number", "null"],
+                    "description": "firstContentfulPaint"
+                },
+                "lp": {
+                    "type": ["number", "null"],
+                    "description": "largestContentfulPaint"
+                }
+            }
+        },
+        "nt": {
+            "type": ["object", "null"],
+            "description": "navigation-timing",
+            "properties": {
+                "fs": {
+                    "type": ["number", "null"],
+                    "description": "fetchStart"
+                },
+                "ls": {
+                    "type": ["number", "null"],
+                    "description": "domainLookupStart"
+                },
+                "le": {
+                    "type": ["number", "null"],
+                    "description": "domainLookupEnd"
+                },
+                "cs": {
+                    "type": ["number", "null"],
+                    "description": "connectStart"
+                },
+                "ce": {
+                    "type": ["number", "null"],
+                    "description": "connectEnd"
+                },
+                "qs": {
+                    "type": ["number", "null"],
+                    "description": "requestStart"
+                },
+                "rs": {
+                    "type": ["number", "null"],
+                    "description": "responseStart"
+                },
+                "re": {
+                    "type": ["number", "null"],
+                    "description": "responseEnd"
+                },
+                "dl": {
+                    "type": ["number", "null"],
+                    "description": "domLoading"
+                },
+                "di": {
+                    "type": ["number", "null"],
+                    "description": "domInteractive"
+                },
+                "ds": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventStart"
+                },
+                "de": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventEnd"
+                },
+                "dc": {
+                    "type": ["number", "null"],
+                    "description": "domComplete"
+                },
+                "es": {
+                    "type": ["number", "null"],
+                    "description": "loadEventStart"
+                },
+                "ee": {
+                    "type": ["number", "null"],
+                    "description": "loadEventEnd"
+                }
+            }
+        }
+    }
+}

--- a/schema/apm-7.8/docs/spec/transactions/rum_v3_transaction.json
+++ b/schema/apm-7.8/docs/spec/transactions/rum_v3_transaction.json
@@ -1,0 +1,107 @@
+{
+    "$id": "docs/spec/transactions/rum_v3_transaction.json",
+    "type": "object",
+    "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
+    "allOf": [
+        {
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Hex encoded 64 random bits ID of the transaction.",
+                    "maxLength": 1024
+                },
+                "tid": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "pid": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Only root transactions of a trace do not have a parent_id, otherwise it needs to be set.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "t": {
+                    "type": "string",
+                    "description": "Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)",
+                    "maxLength": 1024
+                },
+                "n": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
+                    "maxLength": 1024
+                },
+                "y": {
+                    "type": ["array", "null"],
+                    "$ref": "../spans/rum_v3_span.json"
+                },
+                "me": {
+                    "type": ["array", "null"],
+                    "$ref": "../metricsets/rum_v3_metricset.json"
+                },
+                "yc": {
+                    "type": "object",
+                    "properties": {
+                        "sd": {
+                            "type": "integer",
+                            "description": "Number of correlated spans that are recorded."
+                        },
+                        "dd": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "description": "Number of spans that have been dd by the a recording the x."
+                        }
+                    },
+                    "required": [
+                        "sd"
+                    ]
+                },
+                "c": {
+                    "$ref": "../rum_v3_context.json"
+                },
+                "d": {
+                    "type": "number",
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
+                },
+                "rt": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
+                    "maxLength": 1024
+                },
+                "k": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
+                    "$ref": "rum_v3_mark.json"
+                },
+                "sm": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                }
+            },
+            "required": [
+                "id",
+                "tid",
+                "yc",
+                "d",
+                "t"
+            ]
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/transactions/transaction.json
+++ b/schema/apm-7.8/docs/spec/transactions/transaction.json
@@ -1,0 +1,73 @@
+{
+    "$id": "docs/spec/transactions/transaction.json",
+    "type": "object",
+    "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
+    "allOf": [
+        { "$ref": "../timestamp_epoch.json" },
+        { "$ref": "../transaction_name.json" },
+        { "$ref": "../transaction_type.json" },
+        {  
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Hex encoded 64 random bits ID of the transaction.", 
+                    "maxLength": 1024
+                },
+                "trace_id": {
+                    "description": "Hex encoded 128 random bits ID of the correlated trace.", 
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "parent_id": {
+                    "description": "Hex encoded 64 random bits ID of the parent transaction or span. Only root transactions of a trace do not have a parent_id, otherwise it needs to be set.", 
+                    "type": ["string", "null"],
+                    "maxLength": 1024
+                },
+                "span_count": {
+                    "type": "object",
+                    "properties": {
+                        "started": {
+                            "type": "integer",
+                            "description": "Number of correlated spans that are recorded."
+
+                        },
+                        "dropped": {
+                            "type": ["integer","null"],
+                            "description": "Number of spans that have been dropped by the agent recording the transaction."
+
+                        }
+                    },
+                    "required": ["started"]
+                },
+                "context": {
+                    "$ref": "../context.json"
+                },
+                "duration": {
+                    "type": "number",
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
+                },
+                "result": {
+                    "type": ["string", "null"],
+                    "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
+                    "maxLength": 1024
+                },
+                "marks": {
+                    "type": ["object", "null"],
+                    "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
+                    "patternProperties": {
+                        "^[^.*\"]*$": {
+                            "$ref": "mark.json"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "sampled": {
+                    "type": ["boolean", "null"],
+                    "description": "Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true."
+                }
+            },
+            "required": ["id", "trace_id", "span_count", "duration", "type"]
+        }
+    ]
+}

--- a/schema/apm-7.8/docs/spec/user.json
+++ b/schema/apm-7.8/docs/spec/user.json
@@ -1,0 +1,22 @@
+{
+    "$id": "docs/spec/user.json",
+    "title": "User",
+    "type": ["object", "null"],
+    "properties": {
+        "id": {
+            "description": "Identifier of the logged in user, e.g. the primary key of the user",
+            "type": ["string", "integer", "null"],
+            "maxLength": 1024
+        },
+        "email": {
+            "description": "Email of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        },
+        "username": {
+            "description": "The username of the logged in user",
+            "type": ["string", "null"],
+            "maxLength": 1024
+        }
+    }
+}

--- a/src/Events/Error.php
+++ b/src/Events/Error.php
@@ -16,6 +16,7 @@ class Error extends EventBean implements \JsonSerializable
 {
     use Stacktrace;
 
+    protected $eventType = 'error';
     /**
      * Error | Exception
      *
@@ -43,7 +44,7 @@ class Error extends EventBean implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'error' => [
+            $this->eventType => [
                 'id'             => $this->getId(),
                 'transaction_id' => $this->getParentId(),
                 'parent_id'      => $this->getParentId(),

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -19,6 +19,13 @@ class EventBean
         TRACE_ID_BITS = 128;
 
     /**
+     * Event Type
+     *
+     * @var string
+     */
+    protected $eventType = 'generic';
+
+    /**
      * Event Id
      *
      * @var string
@@ -100,6 +107,16 @@ class EventBean
         if ($parent !== null) {
             $this->setParent($parent);
         }
+    }
+
+    /**
+     * Get the Event Type
+     *
+     * @return string
+     */
+    public function getEventType(): string
+    {
+        return $this->eventType;
     }
 
     /**

--- a/src/Events/Metadata.php
+++ b/src/Events/Metadata.php
@@ -15,6 +15,7 @@ use Nipwaayoni\Helper\Encoding;
  */
 class Metadata extends EventBean implements \JsonSerializable
 {
+    protected $eventType = 'metadata';
 
     /**
      * @var Config
@@ -39,7 +40,7 @@ class Metadata extends EventBean implements \JsonSerializable
     final public function jsonSerialize(): array
     {
         return [
-            'metadata' => [
+            $this->eventType => [
                 'service' => [
                     'name'    => Encoding::keywordField($this->config->get('appName')),
                     'version' => Encoding::keywordField($this->config->get('appVersion')),

--- a/src/Events/Metricset.php
+++ b/src/Events/Metricset.php
@@ -12,6 +12,7 @@ namespace Nipwaayoni\Events;
  */
 class Metricset extends EventBean implements \JsonSerializable
 {
+    protected $eventType = 'metricset';
     /**
      * @var array
      */
@@ -45,7 +46,7 @@ class Metricset extends EventBean implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'metricset' => [
+            $this->eventType => [
                 'samples'   => $this->samples,
 //                'tags'      => $this->tags,
                 'timestamp' => $this->getTimestamp(),

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -17,6 +17,7 @@ class Span extends TraceableEvent implements \JsonSerializable
 {
     use Stacktrace;
 
+    protected $eventType = 'span';
     /**
      * @var string
      */
@@ -134,7 +135,7 @@ class Span extends TraceableEvent implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'span' => [
+            $this->eventType => [
                 'id'             => $this->getId(),
                 'transaction_id' => $this->getParentId(),
                 'trace_id'       => $this->getTraceId(),

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -113,6 +113,11 @@ class Span extends TraceableEvent implements \JsonSerializable
         $this->type = trim($type);
     }
 
+    public function setDuration(int $duration)
+    {
+        $this->duration = $duration;
+    }
+
     /**
      * Set a complimentary Stacktrace for the Span
      *

--- a/src/Events/Transaction.php
+++ b/src/Events/Transaction.php
@@ -14,6 +14,8 @@ use Nipwaayoni\Helper\Encoding;
  */
 class Transaction extends TraceableEvent implements \JsonSerializable
 {
+    protected $eventType = 'transaction';
+
     /**
      * Transaction Name
      *
@@ -136,7 +138,7 @@ class Transaction extends TraceableEvent implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'transaction' => [
+            $this->eventType => [
                 'trace_id'   => $this->getTraceId(),
                 'id'         => $this->getId(),
                 'parent_id'  => $this->getParentId(),

--- a/tests/Events/ErrorTest.php
+++ b/tests/Events/ErrorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Nipwaayoni\Tests\Events;
+
+use Nipwaayoni\Events\Error;
+use Nipwaayoni\Tests\SchemaTestCase;
+
+class ErrorTest extends SchemaTestCase
+{
+    public function schemaVersionDataProvider(): array
+    {
+        return [
+            // TODO add support for multiple schema versions
+            // '6.7 v1 errors' => ['6.7', 'errors/v1_error.json'],
+            '6.7 v2 errors' => ['6.7', 'errors/v2_error.json'],
+            '7.6' => ['7.6', 'errors/error.json'],
+            '7.8' => ['7.8', 'errors/error.json'],
+        ];
+    }
+
+    /**
+     * Tests that the object output by this class is tested against the supported APM schema versions.
+     * The abstract method is implemented here for transparency during the PHPUnit test run and
+     * reporting.
+     */
+    public function testTestsSupportedSchemaVersions(): void
+    {
+        $this->assertSupportedSchemasAreTested($this->findUntestedSupportedSchemaVersions());
+    }
+
+    /**
+     * @dataProvider schemaVersionDataProvider
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     */
+    public function testProducesValidJson(string $schemaVersion, string $schemaFile): void
+    {
+        $error = new Error(new \Exception(), []);
+
+        $this->validateObjectAgainstSchema($error, $schemaVersion, $schemaFile);
+    }
+}

--- a/tests/Events/MetadataTest.php
+++ b/tests/Events/MetadataTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Nipwaayoni\Tests\Events;
+
+use Nipwaayoni\Events\Metadata;
+use Nipwaayoni\Helper\Config;
+use Nipwaayoni\Tests\SchemaTestCase;
+
+class MetadataTest extends SchemaTestCase
+{
+    public function schemaVersionDataProvider(): array
+    {
+        return [
+            '6.7' => ['6.7', 'metadata.json'],
+            '7.6' => ['7.6', 'metadata.json'],
+            '7.8' => ['7.8', 'metadata.json'],
+        ];
+    }
+
+    public function testTestsSupportedSchemaVersions(): void
+    {
+        $this->assertSupportedSchemasAreTested($this->findUntestedSupportedSchemaVersions());
+    }
+
+    /**
+     * @dataProvider schemaVersionDataProvider
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     * @throws \Nipwaayoni\Exception\MissingAppNameException
+     */
+    public function testProducesValidJson(string $schemaVersion, string $schemaFile): void
+    {
+        $metadata = new Metadata([], new Config(['appName' => 'SchemaTest']));
+
+        $this->validateObjectAgainstSchema($metadata, $schemaVersion, $schemaFile);
+    }
+}

--- a/tests/Events/MetricsetTest.php
+++ b/tests/Events/MetricsetTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Nipwaayoni\Tests\Events;
+
+use Nipwaayoni\Events\Metricset;
+use Nipwaayoni\Tests\SchemaTestCase;
+
+class MetricsetTest extends SchemaTestCase
+{
+    public function schemaVersionDataProvider(): array
+    {
+        return [
+            // TODO add support for multiple schema versions
+            // '6.7 v1 metricset' => ['6.7', 'metricsets/v1_metricset.json'],
+            '6.7 v2 metricset' => ['6.7', 'metricsets/v2_metricset.json'],
+            '7.6' => ['7.6', 'metricsets/metricset.json'],
+            '7.8' => ['7.8', 'metricsets/metricset.json'],
+        ];
+    }
+
+    public function testTestsSupportedSchemaVersions(): void
+    {
+        $this->assertSupportedSchemasAreTested($this->findUntestedSupportedSchemaVersions());
+    }
+
+    /**
+     * @dataProvider schemaVersionDataProvider
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     * @throws \Nipwaayoni\Exception\MissingAppNameException
+     */
+    public function testProducesValidJson(string $schemaVersion, string $schemaFile): void
+    {
+        $metricset = new Metricset(['my.metric' => 123]);
+
+        $this->validateObjectAgainstSchema($metricset, $schemaVersion, $schemaFile);
+    }
+}

--- a/tests/Events/SpanTest.php
+++ b/tests/Events/SpanTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Nipwaayoni\Tests\Events;
+
+use Nipwaayoni\Events\EventBean;
+use Nipwaayoni\Events\Span;
+use Nipwaayoni\Tests\SchemaTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SpanTest extends SchemaTestCase
+{
+    public function schemaVersionDataProvider(): array
+    {
+        return [
+            // TODO add support for multiple schema versions
+            // '6.7 v1 span' => ['6.7', 'spans/v1_span.json'],
+            '6.7 v2 span' => ['6.7', 'spans/v2_span.json'],
+            '7.6' => ['7.6', 'spans/span.json'],
+            '7.8' => ['7.8', 'spans/span.json'],
+        ];
+    }
+
+    public function testTestsSupportedSchemaVersions(): void
+    {
+        $this->assertSupportedSchemasAreTested($this->findUntestedSupportedSchemaVersions());
+    }
+
+    /**
+     * @dataProvider schemaVersionDataProvider
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     * @throws \Nipwaayoni\Exception\MissingAppNameException
+     */
+    public function testProducesValidJson(string $schemaVersion, string $schemaFile): void
+    {
+        /** @var EventBean|MockObject $parent */
+        $parent = $this->createMock(EventBean::class);
+        $parent->method('getId')->willReturn('123');
+        $parent->method('getTraceId')->willReturn('456');
+
+        $span = new Span('MySpan', $parent);
+
+        $this->validateObjectAgainstSchema($span, $schemaVersion, $schemaFile);
+    }
+}

--- a/tests/Events/TransactionTest.php
+++ b/tests/Events/TransactionTest.php
@@ -3,13 +3,41 @@
 namespace Nipwaayoni\Tests\Events;
 
 use Nipwaayoni\Events\Transaction;
-use Nipwaayoni\Tests\TestCase;
+use Nipwaayoni\Tests\SchemaTestCase;
 
 /**
  * Test Case for @see \Nipwaayoni\Events\Transaction
  */
-final class TransactionTest extends TestCase
+final class TransactionTest extends SchemaTestCase
 {
+    public function schemaVersionDataProvider(): array
+    {
+        return [
+            // TODO add support for multiple schema versions
+            // '6.7 v1 transaction' => ['6.7', 'transactions/v1_transaction.json'],
+            '6.7 v2 transaction' => ['6.7', 'transactions/v2_transaction.json'],
+            '7.6' => ['7.6', 'transactions/transaction.json'],
+            '7.8' => ['7.8', 'transactions/transaction.json'],
+        ];
+    }
+
+    public function testTestsSupportedSchemaVersions(): void
+    {
+        $this->assertSupportedSchemasAreTested($this->findUntestedSupportedSchemaVersions());
+    }
+
+    /**
+     * @dataProvider schemaVersionDataProvider
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     * @throws \Nipwaayoni\Exception\MissingAppNameException
+     */
+    public function testProducesValidJson(string $schemaVersion, string $schemaFile): void
+    {
+        $transaction = new Transaction('MyTransaction', []);
+
+        $this->validateObjectAgainstSchema($transaction, $schemaVersion, $schemaFile);
+    }
 
     /**
      * @covers \Nipwaayoni\Events\EventBean::getId

--- a/tests/Events/TransactionTest.php
+++ b/tests/Events/TransactionTest.php
@@ -64,7 +64,6 @@ final class TransactionTest extends SchemaTestCase
      *
      * @covers \Nipwaayoni\Events\EventBean::setParent
      * @covers \Nipwaayoni\Events\EventBean::getTraceId
-     * @covers \Nipwaayoni\Events\EventBean::ensureGetTraceId
      */
     public function testParentReference()
     {

--- a/tests/SchemaTestCase.php
+++ b/tests/SchemaTestCase.php
@@ -1,0 +1,137 @@
+<?php
+
+
+namespace Nipwaayoni\Tests;
+
+use JsonSchema\Validator;
+use Nipwaayoni\Events\EventBean;
+
+abstract class SchemaTestCase extends TestCase
+{
+    public const SUPPORTED_SCHEMA_VERSIONS = [
+        // TODO add support for pre-7 end points for backward compatibility, the schema is not enough
+        // '6.7',
+        '7.6',
+        '7.8',
+    ];
+
+    /**
+     * Tests that the object output by a class is tested against the supported APM schema versions.
+     * The abstract method is defined as abstract and must be implemented in the test classes for
+     * transparency during the PHPUnit test run and reporting.
+     *
+     * The only contents of the method should be:
+     *
+     *   $this->assertSupportedSchemasAreTested($this->findUntestedSupportedSchemaVersions());
+     */
+    abstract public function testTestsSupportedSchemaVersions(): void;
+
+    /**
+     * Tests that the object output by a class validates for the supported APM schema versions.
+     * The abstract method is defined as abstract and must be implemented in the test classes for
+     * transparency during the PHPUnit test run and reporting.
+     *
+     * The test method must use the 'schemaVersionDataProvider' data provider method.
+     *
+     * The test method must call the validation method:
+     *
+     *   $this->validateObjectAgainstSchema($object, $schemaVersion, $schemaFile);
+     *
+     * This method represents the minimum required test and should use an object in it's most
+     * generic, unmodified state. You should create additional tests to cover variations of
+     * object in different states using this test as a model.
+     *
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     */
+    abstract public function testProducesValidJson(string $schemaVersion, string $schemaFile): void;
+
+    /**
+     * Data provider method for PHPUnit to construct schema validate tests. The method must
+     * return an array of arrays. The key should be in the form:
+     *
+     *   M.N[ specifier]
+     *
+     * Examples:
+     *
+     *   6.5 constant v1
+     *   7.1
+     *   7.5
+     *
+     * The first item of the value array must be the M.N schema version.
+     *
+     * The second item of the value array must be the path to the schema JSON file relative
+     * to the 'doc' directory.
+     *
+     * Example:
+     *
+     *   return [
+     *     '7.6' => ['7.6', 'metadata.json'],
+     *   ];
+     *
+     * @return array
+     */
+    abstract public function schemaVersionDataProvider(): array;
+
+    protected function findUntestedSupportedSchemaVersions(): array
+    {
+        $provided = $this->schemaVersionDataProvider();
+
+        $providedVersions = array_reduce($provided, function (array $c, array $values) {
+            // Data provider methods must follow the convention of the schema version being the first value
+            if (!in_array($values[0], $c)) {
+                $c[] = $values[0];
+            }
+            return $c;
+        }, []);
+
+        return array_diff(self::SUPPORTED_SCHEMA_VERSIONS, $providedVersions);
+    }
+
+    protected function assertSupportedSchemasAreTested(array $untested): void
+    {
+        $this->assertCount(0, $untested, 'Untested schema versions: ' . implode(', ', $untested));
+    }
+
+    /**
+     * @param EventBean $eventBean
+     * @param string $schemaVersion
+     * @param string $schemaFile
+     * @return Validator
+     */
+    protected function validateObjectAgainstSchema(EventBean $eventBean, string $schemaVersion, string $schemaFile): void
+    {
+        try {
+            // Objects currently serialize under a type key. Eventually we will move the key responsibility
+            // to a serializer class. For now, we need to extract the object based on the type.
+            $type = $eventBean->getEventType();
+            $data = json_decode(json_encode($eventBean))->$type;
+        } catch (\Exception $e) {
+            $details = get_class($eventBean) . ' ' . $schemaVersion . ' ' . $schemaFile;
+            $this->fail('JSON conversion error (' . $details . '): ' . $e->getMessage());
+        }
+
+        $validator = new Validator();
+        try {
+            $schemaFilePath = realpath(__DIR__ . '/../schema/apm-' . $schemaVersion . '/docs/spec/' . $schemaFile);
+            $validator->validate($data, (object)['$ref' => 'file://' . $schemaFilePath]);
+        } catch (\Exception $e) {
+            $details = get_class($eventBean) . ' ' . $schemaVersion . ' ' . $schemaFile;
+            $this->fail('JSON schema error (' . $details . '): ' . $e->getMessage());
+        }
+
+        $this->assertTrue($validator->isValid(), $this->getValidationErrors($validator));
+    }
+
+    private function getValidationErrors(Validator $validator): string
+    {
+        if ($validator->isValid()) {
+            return '';
+        }
+
+        return implode("\n", array_reduce($validator->getErrors(), function (array $c, array $error) {
+            $c[] = sprintf("[%s] %s", $error['property'], $error['message']);
+            return $c;
+        }, []));
+    }
+}

--- a/tests/Stores/TransactionsStoreTest.php
+++ b/tests/Stores/TransactionsStoreTest.php
@@ -14,7 +14,7 @@ final class TransactionsStoreTest extends TestCase
 
   /**
    * @covers \Nipwaayoni\Stores\TransactionsStore::register
-   * @covers \Nipwaayoni\Stores\TransactionsStore::get
+   * @covers \Nipwaayoni\Stores\TransactionsStore::fetch
    */
     public function testTransactionRegistrationAndFetch()
     {
@@ -58,7 +58,7 @@ final class TransactionsStoreTest extends TestCase
     /**
      * @depends testTransactionRegistrationAndFetch
      *
-     * @covers \Nipwaayoni\Stores\TransactionsStore::get
+     * @covers \Nipwaayoni\Stores\TransactionsStore::fetch
      */
     public function testFetchUnknownTransaction()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: tepeds
- * Date: 2019-02-09
- * Time: 10:49
- */
 
 namespace Nipwaayoni\Tests;
 


### PR DESCRIPTION
Closes #16 

Still a work in progress. This introduces a framework for the testing using 6.7, 7.6 and 7.8 to start. Minimal tests for Metadata and Error have been implemented.