### PR TITLE
Add TimerFactory class and use in Span

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -9,3 +9,5 @@
 * The second argument to the `Agent` constructor must now be a `ContextCollection` object rather than an array of context values.
 * The `Config` class no longer accepts `httpClient`, `env` or `cookies` keys and will cause an `UnsupportedConfigurationValueException` if given.
 * Specifying environment variable and HTTP cookie names to include in APM events must now be done through a `ContextCollection` object or through the `AgentBuilder` class.
+* `Transaction` class constructors no longer accept a start time. You must now pass the start time to the `Transaction::start()` method consistent with `Span` objects.
+* The `EventFactoryInterface::newTransaction` method signature has changed to remove the `$start` argument.

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -155,12 +155,11 @@ class Agent
     /**
      * Start the Transaction capturing
      *
-     * @throws \Nipwaayoni\Exception\Transaction\DuplicateTransactionNameException
-     *
      * @param string $name
-     * @param array  $context
-     *
+     * @param array $context
+     * @param float|null $start
      * @return Transaction
+     * @throws DuplicateTransactionNameException
      */
     public function startTransaction(string $name, array $context = [], float $start = null): Transaction
     {
@@ -168,15 +167,13 @@ class Agent
 
         // Create and Store Transaction
         $this->transactionsStore->register(
-            $this->factory()->newTransaction($name, $eventContext->toArray(), $start)
+            $this->factory()->newTransaction($name, $eventContext->toArray())
         );
 
         // Start the Transaction
         $transaction = $this->transactionsStore->fetch($name);
 
-        if (null === $start) {
-            $transaction->start();
-        }
+        $transaction->start($start);
 
         return $transaction;
     }

--- a/src/Events/DefaultEventFactory.php
+++ b/src/Events/DefaultEventFactory.php
@@ -15,9 +15,9 @@ final class DefaultEventFactory implements EventFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function newTransaction(string $name, array $contexts, float $start = null): Transaction
+    public function newTransaction(string $name, array $contexts): Transaction
     {
-        return new Transaction($name, $contexts, $start);
+        return new Transaction($name, $contexts);
     }
 
     /**

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -54,7 +54,7 @@ class EventBean
      *
      * @var int
      */
-    private $timestamp;
+    protected $timestamp;
 
     /**
      * Event Metadata

--- a/src/Events/EventFactoryInterface.php
+++ b/src/Events/EventFactoryInterface.php
@@ -22,7 +22,7 @@ interface EventFactoryInterface
      *
      * @return Transaction
      */
-    public function newTransaction(string $name, array $contexts, float $start = null): Transaction;
+    public function newTransaction(string $name, array $contexts): Transaction;
 
     /**
      * Creates a new Span

--- a/src/Factory/TimerFactory.php
+++ b/src/Factory/TimerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace Nipwaayoni\Factory;
+
+use Nipwaayoni\Helper\Timer;
+
+class TimerFactory
+{
+    public function newTimer(float $startTime = null): Timer
+    {
+        return new Timer($startTime);
+    }
+}

--- a/src/Helper/Timer.php
+++ b/src/Helper/Timer.php
@@ -31,6 +31,22 @@ class Timer
     }
 
     /**
+     * @return bool
+     */
+    public function isStarted(): bool
+    {
+        return null !== $this->startedOn;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNotStarted(): bool
+    {
+        return null === $this->startedOn;
+    }
+
+    /**
      * Start the Timer
      *
      * @return void
@@ -59,6 +75,11 @@ class Timer
         }
 
         $this->stoppedOn = microtime(true);
+    }
+
+    public function getStartTime(): float
+    {
+        return $this->startedOn;
     }
 
     /**

--- a/tests/Events/TransactionTest.php
+++ b/tests/Events/TransactionTest.php
@@ -3,13 +3,45 @@
 namespace Nipwaayoni\Tests\Events;
 
 use Nipwaayoni\Events\Transaction;
+use Nipwaayoni\Factory\TimerFactory;
+use Nipwaayoni\Helper\Timer;
 use Nipwaayoni\Tests\SchemaTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test Case for @see \Nipwaayoni\Events\Transaction
  */
 final class TransactionTest extends SchemaTestCase
 {
+    /** @var Transaction  */
+    private $transaction;
+
+    /** @var Timer|MockObject  */
+    private $timer;
+
+    /** @var TimerFactory|MockObject  */
+    private $timerFactory;
+
+    /** @var float */
+    private $timestamp;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->timestamp = microtime(true);
+        $this->timer = $this->createMock(Timer::class);
+        $this->timer->method('getStartTime')
+            ->willReturnCallback(function () {
+                return $this->timestamp;
+            });
+
+        $this->timerFactory = $this->createMock(TimerFactory::class);
+        $this->timerFactory->method('newtimer')->willReturn($this->timer);
+
+        $this->transaction = new Transaction('MyTransactioon', [], $this->timerFactory);
+    }
+
     public function schemaVersionDataProvider(): array
     {
         return [
@@ -77,5 +109,54 @@ final class TransactionTest extends SchemaTestCase
         $this->assertEquals($arr['transaction']['parent_id'], $parent->getId());
         $this->assertEquals($arr['transaction']['trace_id'], $parent->getTraceId());
         $this->assertEquals($child->getTraceId(), $parent->getTraceId());
+    }
+
+    /**
+     * @param float|null $startTime
+     * @throws \Nipwaayoni\Exception\Timer\AlreadyRunningException
+     * @dataProvider spanStartTimes
+     */
+    public function testPresentsCorrectTimestampAndDurationInJson(float $startTime = null): void
+    {
+        $this->timestamp = 1591785019.5996;
+        $duration = 2.34;
+
+        $this->timer->expects($this->once())->method('getDurationInMilliseconds')
+            ->willReturn($duration);
+
+        $this->timerFactory->expects($this->once())->method('newTimer')
+            ->with($this->equalTo($startTime))
+            ->willReturn($this->timer);
+
+        $this->transaction->start($startTime);
+        $this->transaction->stop();
+
+        $payload = json_decode(json_encode($this->transaction), true);
+
+        $this->assertEquals((int) round($this->timestamp * 1000000), $payload['transaction']['timestamp']);
+        $this->assertEquals($duration, $payload['transaction']['duration']);
+    }
+
+    /**
+     * @throws \Nipwaayoni\Exception\Timer\AlreadyRunningException
+     *
+     * @dataProvider spanStartTimes
+     */
+    public function testUsesCorrectStartTimeForTimer(float $startTime = null): void
+    {
+        $this->timerFactory->expects($this->once())->method('newTimer')
+            ->with($this->equalTo($startTime))
+            ->willReturn($this->timer);
+
+        $this->transaction->start($startTime);
+        $this->transaction->stop();
+    }
+
+    public function spanStartTimes(): array
+    {
+        return [
+            'null start time' => [null],
+            'set start time' => [microtime(true)],
+        ];
     }
 }

--- a/tests/Helper/TimerTest.php
+++ b/tests/Helper/TimerTest.php
@@ -129,4 +129,29 @@ final class TimerTest extends TestCase
         $this->expectException(AlreadyRunningException::class);
         $timer->start();
     }
+
+    public function testReturnsStartTime(): void
+    {
+        $startTime = microtime(true);
+        $timer = new Timer($startTime);
+
+        $this->assertEquals($startTime, $timer->getStartTime());
+    }
+
+    public function testCanAssertIfTimerIsStarted(): void
+    {
+        $timer = new Timer();
+
+        $this->assertFalse($timer->isStarted());
+        $this->assertTrue($timer->isNotStarted());
+    }
+
+    public function testCanAssertIfTimerIsNotStarted(): void
+    {
+        $timer = new Timer();
+        $timer->start();
+
+        $this->assertTrue($timer->isStarted());
+        $this->assertFalse($timer->isNotStarted());
+    }
 }


### PR DESCRIPTION
Here is my alternative with a `TimerFactory` class. The testing, in my opinion, is much simpler and easier to follow.

While the `TimerFactory` class is barely more than a `return new Timer()` right now, it serves to make testing easier. Maybe that's all it will ever do, but I personally feel the benefit is worth the added class.