### PR TITLE
Implement transaction sampling rate

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -222,6 +222,10 @@ class Agent implements ApmAgent
      */
     public function putEvent(EventBean $event)
     {
+        if (!$event->isSampled()) {
+            return;
+        }
+
         $this->connector->putEvent($event);
     }
 

--- a/src/AgentBuilder.php
+++ b/src/AgentBuilder.php
@@ -155,7 +155,7 @@ class AgentBuilder
         $factory = new DefaultEventFactory();
 
         $factory->setTransactionSamplingStrategy(
-            new TransactionSamplingStrategy($this->config->get('transactionSamplingRate'))
+            new TransactionSamplingStrategy($this->config->get('transactionSampleRate'))
         );
 
         return $factory;

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,14 +72,15 @@ class Config
     private function getDefaultConfig(): array
     {
         return [
-            'serverUrl'      => 'http://127.0.0.1:8200',
-            'secretToken'    => null,
-            'hostname'       => gethostname(),
-            'appVersion'     => '',
-            'active'         => true,
-            'timeout'        => 10,
-            'environment'    => 'development',
-            'backtraceLimit' => 0,
+            'serverUrl'               => 'http://127.0.0.1:8200',
+            'secretToken'             => null,
+            'hostname'                => gethostname(),
+            'appVersion'              => '',
+            'active'                  => true,
+            'timeout'                 => 10,
+            'environment'             => 'development',
+            'backtraceLimit'          => 0,
+            'transactionSamplingRate' => 1,
         ];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,15 +72,15 @@ class Config
     private function getDefaultConfig(): array
     {
         return [
-            'serverUrl'               => 'http://127.0.0.1:8200',
-            'secretToken'             => null,
-            'hostname'                => gethostname(),
-            'appVersion'              => '',
-            'active'                  => true,
-            'timeout'                 => 10,
-            'environment'             => 'development',
-            'backtraceLimit'          => 0,
-            'transactionSamplingRate' => 1,
+            'serverUrl'             => 'http://127.0.0.1:8200',
+            'secretToken'           => null,
+            'hostname'              => gethostname(),
+            'appVersion'            => '',
+            'active'                => true,
+            'timeout'               => 10,
+            'environment'           => 'development',
+            'backtraceLimit'        => 0,
+            'transactionSampleRate' => 1,
         ];
     }
 }

--- a/src/Events/DefaultEventFactory.php
+++ b/src/Events/DefaultEventFactory.php
@@ -4,6 +4,14 @@ namespace Nipwaayoni\Events;
 
 final class DefaultEventFactory implements EventFactoryInterface
 {
+    /** @var SamplingStrategy */
+    private $transactionSamplingStrategy;
+
+    public function __construct()
+    {
+        $this->transactionSamplingStrategy = new DefaultSamplingStrategy();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -13,11 +21,24 @@ final class DefaultEventFactory implements EventFactoryInterface
     }
 
     /**
+     * Sets the SamplingStrategy to use for Transactions
+     *
+     * @param SamplingStrategy $strategy
+     */
+    public function setTransactionSamplingStrategy(SamplingStrategy $strategy): void
+    {
+        $this->transactionSamplingStrategy = $strategy;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function newTransaction(string $name, array $contexts): Transaction
     {
-        return new Transaction($name, $contexts);
+        $transaction = new Transaction($name, $contexts);
+        $transaction->sampleStrategy($this->transactionSamplingStrategy);
+
+        return $transaction;
     }
 
     /**

--- a/src/Events/DefaultSamplingStrategy.php
+++ b/src/Events/DefaultSamplingStrategy.php
@@ -3,8 +3,7 @@
 
 namespace Nipwaayoni\Events;
 
-
-class SampleStrategy
+class DefaultSamplingStrategy implements SamplingStrategy
 {
     public function sampleEvent(): bool
     {

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -10,7 +10,7 @@ use Nipwaayoni\Helper\Timestamp;
  * EventBean for occurring events such as Exceptions or Transactions
  *
  */
-class EventBean
+class EventBean implements Samplable
 {
     /**
      * Bit Size of ID's
@@ -411,5 +411,20 @@ class EventBean
         }
 
         return $context;
+    }
+
+    public function sampleStrategy(SampleStrategy $strategy): void
+    {
+        // TODO: Implement sampleStrategy() method.
+    }
+
+    public function includeSamples(): bool
+    {
+        return true;
+    }
+
+    public function isSampled(): bool
+    {
+        return true;
     }
 }

--- a/src/Events/EventBean.php
+++ b/src/Events/EventBean.php
@@ -67,6 +67,11 @@ class EventBean implements Samplable
         'type'   => 'generic'
     ];
 
+    /** @var SamplingStrategy */
+    protected $sampleStrategy;
+
+    /** @var bool */
+    protected $includeAsSample = true;
     /**
      * Extended Contexts such as Custom and/or User
      *
@@ -102,6 +107,7 @@ class EventBean implements Samplable
         $this->contexts = array_merge($this->contexts, $contexts);
 
         $this->timestamp = new Timestamp();
+        $this->sampleStrategy = new DefaultSamplingStrategy();
 
         // Set Parent Transaction
         if ($parent !== null) {
@@ -413,9 +419,9 @@ class EventBean implements Samplable
         return $context;
     }
 
-    public function sampleStrategy(SampleStrategy $strategy): void
+    public function sampleStrategy(SamplingStrategy $strategy): void
     {
-        // TODO: Implement sampleStrategy() method.
+        $this->sampleStrategy = $strategy;
     }
 
     public function includeSamples(): bool
@@ -425,6 +431,6 @@ class EventBean implements Samplable
 
     public function isSampled(): bool
     {
-        return true;
+        return $this->includeAsSample;
     }
 }

--- a/src/Events/Samplable.php
+++ b/src/Events/Samplable.php
@@ -3,15 +3,14 @@
 
 namespace Nipwaayoni\Events;
 
-
 interface Samplable
 {
     /**
      * Sets the strategy used for determining of the object should be sampled.
      *
-     * @param SampleStrategy $strategy
+     * @param SamplingStrategy $strategy
      */
-    public function sampleStrategy(SampleStrategy $strategy): void;
+    public function sampleStrategy(SamplingStrategy $strategy): void;
 
     /**
      * Indicates if the object's descendent events should be included as samples.
@@ -25,5 +24,5 @@ interface Samplable
      *
      * @return bool
      */
-    public function isSampled():bool;
+    public function isSampled(): bool;
 }

--- a/src/Events/Samplable.php
+++ b/src/Events/Samplable.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Nipwaayoni\Events;
+
+
+interface Samplable
+{
+    /**
+     * Sets the strategy used for determining of the object should be sampled.
+     *
+     * @param SampleStrategy $strategy
+     */
+    public function sampleStrategy(SampleStrategy $strategy): void;
+
+    /**
+     * Indicates if the object's descendent events should be included as samples.
+     *
+     * @return bool
+     */
+    public function includeSamples(): bool;
+
+    /**
+     * Indicates if this object itself should be included as a sample.
+     *
+     * @return bool
+     */
+    public function isSampled():bool;
+}

--- a/src/Events/SampleStrategy.php
+++ b/src/Events/SampleStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Nipwaayoni\Events;
+
+
+class SampleStrategy
+{
+    public function sampleEvent(): bool
+    {
+        return true;
+    }
+}

--- a/src/Events/SamplingStrategy.php
+++ b/src/Events/SamplingStrategy.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Nipwaayoni\Events;
+
+interface SamplingStrategy
+{
+    public function sampleEvent(): bool;
+}

--- a/src/Events/Span.php
+++ b/src/Events/Span.php
@@ -65,7 +65,12 @@ class Span extends TraceableEvent implements \JsonSerializable
     {
         parent::__construct([]);
         $this->name  = trim($name);
+
         $this->setParent($parent);
+
+        // Spans are only included when the parent transaction is sampled.
+        $this->includeAsSample = $parent->includeSamples();
+
         $this->timerFactory = $timerFactory ?? new TimerFactory();
     }
 

--- a/src/Events/Transaction.php
+++ b/src/Events/Transaction.php
@@ -149,6 +149,11 @@ class Transaction extends TraceableEvent implements \JsonSerializable
         $this->backtraceLimit = $limit;
     }
 
+    public function includeSamples(): bool
+    {
+        return $this->sampleStrategy->sampleEvent();
+    }
+
     /**
      * Serialize Transaction Event
      *
@@ -156,6 +161,12 @@ class Transaction extends TraceableEvent implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $context = null;
+
+        if ($this->includeSamples()) {
+            $context = $this->getContext();
+        }
+
         return [
             $this->eventType => [
                 'trace_id'   => $this->getTraceId(),
@@ -166,8 +177,8 @@ class Transaction extends TraceableEvent implements \JsonSerializable
                 'timestamp'  => $this->getTimestamp(),
                 'result'     => $this->getMetaResult(),
                 'name'       => Encoding::keywordField($this->getTransactionName()),
-                'context'    => $this->getContext(),
-                'sampled'    => null,
+                'context'    => $context,
+                'sampled'    => $this->includeSamples(),
                 'span_count' => [
                     'started' => 0,
                     'dropped' => 0,

--- a/src/Events/TransactionSamplingStrategy.php
+++ b/src/Events/TransactionSamplingStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Nipwaayoni\Events;
+
+class TransactionSamplingStrategy implements SamplingStrategy
+{
+    /**
+     * @var float
+     */
+    private $rate;
+
+    public function __construct(float $rate = 1.0)
+    {
+        $this->rate = $rate;
+    }
+
+    public function sampleEvent(): bool
+    {
+        $rand = mt_rand(0, mt_getrandmax() - 1) / mt_getrandmax();
+
+        return $rand <= $this->rate;
+    }
+}

--- a/src/Factory/ConnectorFactory.php
+++ b/src/Factory/ConnectorFactory.php
@@ -3,7 +3,6 @@
 
 namespace Nipwaayoni\Factory;
 
-
 use Nipwaayoni\Middleware\Connector;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -19,8 +18,7 @@ class ConnectorFactory
         StreamFactoryInterface $streamFactory = null,
         callable $preCommitCallback = null,
         callable $postCommitCallback = null
-    ): Connector
-    {
+    ): Connector {
         return new Connector(
             $serverUrl,
             $secretToken,

--- a/src/Factory/ConnectorFactory.php
+++ b/src/Factory/ConnectorFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Nipwaayoni\Factory;
+
+
+use Nipwaayoni\Middleware\Connector;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+class ConnectorFactory
+{
+    public function makeConnector(
+        string $serverUrl,
+        ?string $secretToken,
+        ClientInterface $httpClient = null,
+        RequestFactoryInterface $requestFactory = null,
+        StreamFactoryInterface $streamFactory = null,
+        callable $preCommitCallback = null,
+        callable $postCommitCallback = null
+    ): Connector
+    {
+        return new Connector(
+            $serverUrl,
+            $secretToken,
+            $httpClient,
+            $requestFactory,
+            $streamFactory,
+            $preCommitCallback,
+            $postCommitCallback
+        );
+    }
+}

--- a/tests/AgentBuilderTest.php
+++ b/tests/AgentBuilderTest.php
@@ -43,7 +43,7 @@ class AgentBuilderTest extends TestCase
     public function testAppliesTransactionSamplingStrategyToEventFactory(float $rate, bool $expected): void
     {
         $agent = (new AgentBuilder())
-            ->withConfig(new Config(['appName' => 'test', 'transactionSamplingRate' => $rate]))
+            ->withConfig(new Config(['appName' => 'test', 'transactionSampleRate' => $rate]))
             ->build();
 
         $transaction = $agent->startTransaction('My Transaction', []);

--- a/tests/AgentBuilderTest.php
+++ b/tests/AgentBuilderTest.php
@@ -31,4 +31,31 @@ class AgentBuilderTest extends TestCase
 
         $this->assertEquals('Test Created App', $agent->getConfig()->get('appName'));
     }
+
+    /**
+     * @param float $rate
+     * @param bool $expected
+     * @throws \Nipwaayoni\Exception\Helper\UnsupportedConfigurationValueException
+     * @throws \Nipwaayoni\Exception\MissingAppNameException
+     *
+     * @dataProvider transactionSamplingChecks
+     */
+    public function testAppliesTransactionSamplingStrategyToEventFactory(float $rate, bool $expected): void
+    {
+        $agent = (new AgentBuilder())
+            ->withConfig(new Config(['appName' => 'test', 'transactionSamplingRate' => $rate]))
+            ->build();
+
+        $transaction = $agent->startTransaction('My Transaction', []);
+
+        $this->assertEquals($expected, $transaction->includeSamples());
+    }
+
+    public function transactionSamplingChecks(): array
+    {
+        return [
+            '100%' => [1.0, true],
+            '0%' => [0.0, false],
+        ];
+    }
 }

--- a/tests/Events/DefaultEventFactoryTest.php
+++ b/tests/Events/DefaultEventFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Nipwaayoni\Tests\Events;
+
+use Nipwaayoni\Events\DefaultEventFactory;
+use Nipwaayoni\Events\SamplingStrategy;
+use Nipwaayoni\Tests\TestCase;
+
+class DefaultEventFactoryTest extends TestCase
+{
+    public function testAppliesDefaultSamplingStrategyToTransactions(): void
+    {
+        $factory = new DefaultEventFactory();
+
+        $transaction = $factory->newTransaction('My Transaction', []);
+
+        $this->assertTrue($transaction->includeSamples());
+    }
+
+    /**
+     * @dataProvider samplingStrategyChecks
+     */
+    public function testAppliesSamplingStrategyToNewTransactions(SamplingStrategy $strategy, bool $expected): void
+    {
+        $factory = new DefaultEventFactory();
+        $factory->setTransactionSamplingStrategy($strategy);
+
+        $transaction = $factory->newTransaction('My Transaction', []);
+
+        $this->assertEquals($expected, $transaction->includeSamples());
+    }
+    public function samplingStrategyChecks(): array
+    {
+        return [
+            'include' => [$this->makeIncludeStrategy(), true],
+            'exclude' => [$this->makeExcludeStrategy(), false],
+        ];
+    }
+}

--- a/tests/Events/SpanTest.php
+++ b/tests/Events/SpanTest.php
@@ -3,7 +3,9 @@
 namespace Nipwaayoni\Tests\Events;
 
 use Nipwaayoni\Events\EventBean;
+use Nipwaayoni\Events\SamplingStrategy;
 use Nipwaayoni\Events\Span;
+use Nipwaayoni\Events\Transaction;
 use Nipwaayoni\Exception\Events\AlreadyStartedException;
 use Nipwaayoni\Helper\Timer;
 use Nipwaayoni\Factory\TimerFactory;
@@ -133,6 +135,27 @@ class SpanTest extends SchemaTestCase
         return [
             'null start time' => [null],
             'set start time' => [microtime(true)],
+        ];
+    }
+
+    /**
+     * @dataProvider isSampledChecks
+     */
+    public function testIsSampledIsReflectsParentStrategy(SamplingStrategy $strategy): void
+    {
+        $parent = new Transaction('MyParent', []);
+        $parent->sampleStrategy($strategy);
+
+        $this->span = new Span('MySpan', $parent, $this->timerFactory);
+
+        $this->assertEquals($strategy->sampleEvent(), $this->span->isSampled());
+    }
+
+    public function isSampledChecks(): array
+    {
+        return [
+            'include' => [$this->makeIncludeStrategy()],
+            'exclude' => [$this->makeExcludeStrategy()],
         ];
     }
 }

--- a/tests/Helper/ConfigTest.php
+++ b/tests/Helper/ConfigTest.php
@@ -33,7 +33,7 @@ final class ConfigTest extends TestCase
         $this->assertArrayHasKey('appVersion', $config);
         $this->assertArrayHasKey('environment', $config);
         $this->assertArrayHasKey('backtraceLimit', $config);
-        $this->assertArrayHasKey('transactionSamplingRate', $config);
+        $this->assertArrayHasKey('transactionSampleRate', $config);
 
         $this->assertEquals($config['appName'], $appName);
         $this->assertNull($config['secretToken']);
@@ -43,7 +43,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals($config['timeout'], 10);
         $this->assertEquals($config['environment'], 'development');
         $this->assertEquals($config['backtraceLimit'], 0);
-        $this->assertEquals($config['transactionSamplingRate'], 1);
+        $this->assertEquals($config['transactionSampleRate'], 1);
     }
 
     /**

--- a/tests/Helper/ConfigTest.php
+++ b/tests/Helper/ConfigTest.php
@@ -33,6 +33,7 @@ final class ConfigTest extends TestCase
         $this->assertArrayHasKey('appVersion', $config);
         $this->assertArrayHasKey('environment', $config);
         $this->assertArrayHasKey('backtraceLimit', $config);
+        $this->assertArrayHasKey('transactionSamplingRate', $config);
 
         $this->assertEquals($config['appName'], $appName);
         $this->assertNull($config['secretToken']);
@@ -42,6 +43,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals($config['timeout'], 10);
         $this->assertEquals($config['environment'], 'development');
         $this->assertEquals($config['backtraceLimit'], 0);
+        $this->assertEquals($config['transactionSamplingRate'], 1);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Nipwaayoni\Tests;
 use Nipwaayoni\AgentBuilder;
 use Nipwaayoni\ApmAgent;
 use Nipwaayoni\Config;
+use Nipwaayoni\Events\SamplingStrategy;
 use Nipwaayoni\Factory\ConnectorFactory;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
@@ -27,5 +28,23 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $builder->withConfig($components['config']);
 
         return $builder->build();
+    }
+
+    protected function makeSampleStrategy(bool $sampled): SamplingStrategy
+    {
+        $strategy = $this->createMock(SamplingStrategy::class);
+        $strategy->method('sampleEvent')->willReturn($sampled);
+
+        return $strategy;
+    }
+
+    protected function makeIncludeStrategy(): SamplingStrategy
+    {
+        return $this->makeSampleStrategy(true);
+    }
+
+    protected function makeExcludeStrategy(): SamplingStrategy
+    {
+        return $this->makeSampleStrategy(false);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,10 @@
 
 namespace Nipwaayoni\Tests;
 
-use Nipwaayoni\Agent;
 use Nipwaayoni\AgentBuilder;
+use Nipwaayoni\ApmAgent;
 use Nipwaayoni\Config;
+use Nipwaayoni\Factory\ConnectorFactory;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
@@ -16,9 +17,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $this->assertLessThanOrEqual($maxOverhead, $overhead);
     }
 
-    protected function makeAgent(array $components = []): Agent
+    protected function makeAgent(array $components = [], ConnectorFactory $connectorFactory = null): ApmAgent
     {
-        $builder = new AgentBuilder();
+        $builder = new AgentBuilder($connectorFactory);
 
         if (empty($components['config'])) {
             $components['config'] = new Config(['appName' => 'test']);


### PR DESCRIPTION
This adds the option to set a transaction sample rate, consistent with other agents. A sampled transaction includes all context and child events. A non-sampled transaction is recorded, but does not contain context or child events.

The default transaction sample rate is 1.0 (100%) resulting in all transactions being sampled.