### PR TITLE
Change stack trace limit default to 50

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -37,7 +37,7 @@ class Config
         'active' => ['name' => 'enabled', 'default' => true],
         'appName' => ['name' => 'serviceName', 'default' => null],
         'appVersion' => ['name' => 'serviceVersion', 'default' => null],
-        'backtraceLimit' => ['name' => 'stackTraceLimit', 'default' => 0],
+        'backtraceLimit' => ['name' => 'stackTraceLimit', 'default' => 50],
     ];
 
     /** @var string */

--- a/src/Events/TraceableEvent.php
+++ b/src/Events/TraceableEvent.php
@@ -4,6 +4,7 @@ namespace Nipwaayoni\Events;
 
 use Nipwaayoni\Exception\InvalidTraceContextHeaderException;
 use Nipwaayoni\Helper\DistributedTracing;
+use Psr\Http\Message\RequestInterface;
 
 /**
  *
@@ -74,5 +75,10 @@ class TraceableEvent extends EventBean // TODO refactor to DistributedTrace or s
         } else {
             $this->setTraceId(self::generateRandomBitsInHex(self::TRACE_ID_BITS));
         }
+    }
+
+    public function addTraceHeaderToRequest(RequestInterface $request): RequestInterface
+    {
+//        return $request->withHeader()
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nipwaayoni\Tests\Helper;
+namespace Nipwaayoni\Tests;
 
 use Nipwaayoni\Exception\ConfigurationException;
 use Nipwaayoni\Exception\Helper\UnsupportedConfigurationValueException;
@@ -54,7 +54,7 @@ final class ConfigTest extends TestCase
         $this->assertFalse($config['enabled']);
         $this->assertEquals(10, $config['timeout']);
         $this->assertEquals('development', $config['environment']);
-        $this->assertEquals(0, $config['stackTraceLimit']);
+        $this->assertEquals(50, $config['stackTraceLimit']);
         $this->assertEquals(1, $config['transactionSampleRate']);
     }
 


### PR DESCRIPTION
This is consistent with the default in other agent packages: https://docs.google.com/spreadsheets/d/1JJjZotapacA3FkHc2sv_0wiChILi3uKnkwLTjtBmxwU/edit#gid=0