### PR TITLE
Remove final keyword from private method

### DIFF
--- a/src/Events/Error.php
+++ b/src/Events/Error.php
@@ -67,7 +67,7 @@ class Error extends EventBean implements \JsonSerializable
      *
      * @return array
      */
-    final private function mapStacktrace(): array
+    private function mapStacktrace(): array
     {
         $stacktrace = [];
 


### PR DESCRIPTION
There is no reason to have final private method, as it cannot be overridden. And since PHP 8 it produces warning https://3v4l.org/rpkhv