### PR TITLE
Address strlen notices in php 8.1

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}-php${{ matrix.php }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}-${{ matrix.php }}-php${{ matrix.php }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL
           tools: composer:v2, phive
           coverage: xdebug
 

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "php-http/guzzle6-adapter": "^2.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "justinrainbow/json-schema": "^5.2",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "suggest": {
         "php-http/guzzle6-adapter": "PSR-18 compatible Guzzle6 adapter",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,16 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" stopOnFailure="false" stopOnError="false" colors="false" verbose="true" processIsolation="false" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./tests/bootstrap.php"
+         stopOnFailure="false"
+         stopOnError="false"
+         colors="false"
+         verbose="true"
+         processIsolation="false"
+         beStrictAboutChangesToGlobalState="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         convertDeprecationsToExceptions="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
       <directory>./src/</directory>

--- a/src/Helper/Encoding.php
+++ b/src/Helper/Encoding.php
@@ -22,6 +22,10 @@ class Encoding
      */
     public static function keywordField($value)
     {
+        if (empty($value)) {
+            return $value;
+        }
+
         if (strlen($value) > self::KEYWORD_MAX_LENGTH && mb_strlen($value, 'UTF-8') > self::KEYWORD_MAX_LENGTH) { // strlen is faster (O(1)), so we prefer to first check using it, and then double-checking with the slower mb_strlen (O(n)) only when necessary
             return mb_substr($value, 0, self::KEYWORD_MAX_LENGTH - 1, 'UTF-8') . '…';
         }

--- a/tests/Helper/EncodingTest.php
+++ b/tests/Helper/EncodingTest.php
@@ -42,4 +42,21 @@ final class EncodingTest extends TestCase
 
         $this->assertEquals($output, Encoding::keywordField($input));
     }
+
+    /**
+     * @dataProvider emptyInputChecks
+     * @covers \Nipwaayoni\Helper\Encoding::keywordField
+     */
+    public function testEmptyInput($input)
+    {
+        $this->assertEquals($input, Encoding::keywordField($input));
+    }
+
+    public function emptyInputChecks(): array
+    {
+        return [
+            'empty string' => [''],
+            'null' => [null],
+        ];
+    }
 }

--- a/tests/MakesHttpTransactions.php
+++ b/tests/MakesHttpTransactions.php
@@ -29,6 +29,6 @@ trait MakesHttpTransactions
         $handlerStack->push($history);
 
         $client = new \GuzzleHttp\Client(['handler' => $handlerStack]);
-        $this->client = new \Http\Adapter\Guzzle6\Client($client);
+        $this->client = new \Http\Adapter\Guzzle7\Client($client);
     }
 }


### PR DESCRIPTION
PHP 8.1 introduces a deprecation in the `strlen` function:

```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```

The `Encoding` helper class was not always calling `strlen` on the value, so if the value was empty this error occurred under PHP 8.1.

A guard clause has been added to immediately return if the value is empty.