### PR TITLE
Resolve issue where APM requires an int

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A php agent for Elastic APM v2 Intake API",
     "license": "MIT",
     "require" : {
-        "php" : ">= 7.1",
+        "php-64bit" : ">= 7.1",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "php-http/discovery": "^1.7",

--- a/src/Helper/Timestamp.php
+++ b/src/Helper/Timestamp.php
@@ -26,12 +26,14 @@ class Timestamp implements \JsonSerializable
         return round($this->timestamp * self::MICROTIME_MULTIPLIER);
     }
 
-    public function jsonSerialize(): float
+    public function jsonSerialize(): int
     {
         // We use floor her to create a number that looks like an int value to APM.
         // 32-bit PHP cannot handle the integer value size represented by the float
         // and any conversion on our side produces the wrong result. Further, APM
         // requires an int value for timestamp and rejects a string or float.
-        return floor($this->asMicroSeconds());
+        $num = floor($this->asMicroSeconds());
+        $num = sprintf("%.0f", $num);
+        return (int) $num;
     }
 }


### PR DESCRIPTION
Resolves the issue where the current 8.0.1 version Timestamp class creates a float with scientific notation when serialised. 

The APM server requires an integer and therefor fails to ingest results created with this package.

(Tested with PHP 8.1)