### PR TITLE
Update php unit for php 8.4 tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,21 @@ jobs:
     strategy:
       matrix:
         php: [8.4, 8.3, 8.2, 8.1, 8.0, 7.4, 7.3]
+        include:
+          - php: 7.3
+            phpunit: ^9.0
+          - php: 7.4
+            phpunit: ^9.0
+          - php: 8.0
+            phpunit: ^9.0
+          - php: 8.1
+            phpunit: ^10.0
+          - php: 8.2
+            phpunit: ^10.0
+          - php: 8.3
+            phpunit: ^10.0
+          - php: 8.4
+            phpunit: ^10.0
 
     name: PHP${{ matrix.php }}
 
@@ -41,6 +56,7 @@ jobs:
         run: |
           composer install --prefer-dist --no-interaction --no-suggest
           phive --no-progress install --trust-gpg-keys 4AA394086372C20A,CF1A108D0E7AE720,E82B2FB314E9906E
+          phive install phpunit:${{ matrix.phpunit }}
       - name: Execute unit tests
         run:
           tools/phpunit tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.phar
 tools
 .php_cs.cache
 .php-cs-fixer.cache
+.phpunit.cache

--- a/phive.xml
+++ b/phive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpunit" version="^9.0" installed="9.5.21" location="./tools/phpunit" copy="true"/>
+  <phar name="phpunit" version="^10.0" installed="10.5.1" location="./tools/phpunit" copy="true"/>
   <phar name="php-cs-fixer" version="^3.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="true"/>
 </phive>

--- a/tests/AgentBuilderTest.php
+++ b/tests/AgentBuilderTest.php
@@ -62,7 +62,7 @@ class AgentBuilderTest extends TestCase
         $this->assertEquals($expected, $transaction->includeSamples());
     }
 
-    public function transactionSamplingChecks(): array
+    public static function transactionSamplingChecks(): array
     {
         return [
             '100%' => [1.0, true],

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -149,7 +149,7 @@ final class ConfigTest extends TestCase
         ]);
     }
 
-    public function unsupportedConfigOptions(): array
+    public static function unsupportedConfigOptions(): array
     {
         return [
             'environment' => ['env'],
@@ -230,7 +230,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals($configValue, $config->$configName());
     }
 
-    public function environmentVariableChecks(): array
+    public static function environmentVariableChecks(): array
     {
         // Service Name is tested separately
         return [
@@ -328,7 +328,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals($configValue, $config->$configName());
     }
 
-    public function constructorArgumentsChecks(): array
+    public static function constructorArgumentsChecks(): array
     {
         // Service Name is tested separately
         return [
@@ -447,7 +447,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals($optionValue, $config->$preferredOption());
     }
 
-    public function deprecatedOptionsChecks(): array
+    public static function deprecatedOptionsChecks(): array
     {
         return [
             'active/enabled' => ['active', true, 'enabled'],
@@ -519,7 +519,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals($expected, $config->enabled());
     }
 
-    public function activeAndEnabledChecks(): array
+    public static function activeAndEnabledChecks(): array
     {
         return [
             'default' => [
@@ -622,7 +622,7 @@ final class ConfigTest extends TestCase
         ));
     }
 
-    public function logLevelChecks(): array
+    public static function logLevelChecks(): array
     {
         return [
             'debug' => ['debug', true],

--- a/tests/Events/AsyncSpanTest.php
+++ b/tests/Events/AsyncSpanTest.php
@@ -37,7 +37,7 @@ class AsyncSpanTest extends SchemaTestCase
         $this->span = new AsyncSpan('MySpan', $parent, $timerFactory);
     }
 
-    public function schemaVersionDataProvider(): array
+    public static function schemaVersionDataProvider(): array
     {
         return [
             // TODO add support for multiple schema versions

--- a/tests/Events/DefaultEventFactoryTest.php
+++ b/tests/Events/DefaultEventFactoryTest.php
@@ -20,8 +20,10 @@ class DefaultEventFactoryTest extends TestCase
     /**
      * @dataProvider samplingStrategyChecks
      */
-    public function testAppliesSamplingStrategyToNewTransactions(SampleStrategy $strategy, bool $expected): void
+    public function testAppliesSamplingStrategyToNewTransactions(bool $strategyType, bool $expected): void
     {
+        $strategy = $this->makeSampleStrategy($strategyType);
+
         $factory = new DefaultEventFactory();
         $factory->setTransactionSampleStrategy($strategy);
 
@@ -29,11 +31,11 @@ class DefaultEventFactoryTest extends TestCase
 
         $this->assertEquals($expected, $transaction->includeSamples());
     }
-    public function samplingStrategyChecks(): array
+    public static function samplingStrategyChecks(): array
     {
         return [
-            'include' => [$this->makeIncludeStrategy(), true],
-            'exclude' => [$this->makeExcludeStrategy(), false],
+            'include' => [true, true],
+            'exclude' => [false, false],
         ];
     }
 }

--- a/tests/Events/ErrorTest.php
+++ b/tests/Events/ErrorTest.php
@@ -8,7 +8,7 @@ use Nipwaayoni\Tests\SchemaTestCase;
 
 class ErrorTest extends SchemaTestCase
 {
-    public function schemaVersionDataProvider(): array
+    public static function schemaVersionDataProvider(): array
     {
         return [
             // TODO add support for multiple schema versions

--- a/tests/Events/MetadataTest.php
+++ b/tests/Events/MetadataTest.php
@@ -8,7 +8,7 @@ use Nipwaayoni\Tests\SchemaTestCase;
 
 class MetadataTest extends SchemaTestCase
 {
-    public function schemaVersionDataProvider(): array
+    public static function schemaVersionDataProvider(): array
     {
         return [
             '6.7' => ['6.7', 'metadata.json'],

--- a/tests/Events/MetricsetTest.php
+++ b/tests/Events/MetricsetTest.php
@@ -7,7 +7,7 @@ use Nipwaayoni\Tests\SchemaTestCase;
 
 class MetricsetTest extends SchemaTestCase
 {
-    public function schemaVersionDataProvider(): array
+    public static function schemaVersionDataProvider(): array
     {
         return [
             // TODO add support for multiple schema versions

--- a/tests/Events/SpanTest.php
+++ b/tests/Events/SpanTest.php
@@ -51,7 +51,7 @@ class SpanTest extends SchemaTestCase
         $this->span = new Span('MySpan', $this->parent, $this->timerFactory);
     }
 
-    public function schemaVersionDataProvider(): array
+    public static function schemaVersionDataProvider(): array
     {
         return [
             // TODO add support for multiple schema versions
@@ -131,7 +131,7 @@ class SpanTest extends SchemaTestCase
         $this->span->stop();
     }
 
-    public function spanStartTimes(): array
+    public static function spanStartTimes(): array
     {
         return [
             'null start time' => [null],
@@ -142,8 +142,10 @@ class SpanTest extends SchemaTestCase
     /**
      * @dataProvider isSampledChecks
      */
-    public function testIsSampledIsReflectsParentStrategy(SampleStrategy $strategy): void
+    public function testIsSampledIsReflectsParentStrategy(bool $strategyType): void
     {
+        $strategy = $this->makeSampleStrategy($strategyType);
+
         $parent = new Transaction('MyParent', []);
         $parent->sampleStrategy($strategy);
 
@@ -152,11 +154,11 @@ class SpanTest extends SchemaTestCase
         $this->assertEquals($strategy->sampleEvent(), $this->span->isSampled());
     }
 
-    public function isSampledChecks(): array
+    public static function isSampledChecks(): array
     {
         return [
-            'include' => [$this->makeIncludeStrategy()],
-            'exclude' => [$this->makeExcludeStrategy()],
+            'include' => [true],
+            'exclude' => [false],
         ];
     }
 

--- a/tests/Events/TraceableEventTest.php
+++ b/tests/Events/TraceableEventTest.php
@@ -46,7 +46,7 @@ class TraceableEventTest extends TestCase
         unset($_SERVER[$headerName]);
     }
 
-    public function traceParentChecks(): array
+    public static function traceParentChecks(): array
     {
         return [
             'elastic apm header' => [

--- a/tests/Events/TransactionTest.php
+++ b/tests/Events/TransactionTest.php
@@ -44,7 +44,7 @@ final class TransactionTest extends SchemaTestCase
         $this->transaction = new Transaction('MyTransactioon', [], $this->timerFactory);
     }
 
-    public function schemaVersionDataProvider(): array
+    public static function schemaVersionDataProvider(): array
     {
         return [
             // TODO add support for multiple schema versions
@@ -155,7 +155,7 @@ final class TransactionTest extends SchemaTestCase
         $this->transaction->stop();
     }
 
-    public function spanStartTimes(): array
+    public static function spanStartTimes(): array
     {
         return [
             'null start time' => [null],
@@ -166,44 +166,50 @@ final class TransactionTest extends SchemaTestCase
     /**
      * @dataProvider includeSamplesChecks
      */
-    public function testIncludeSamplesReflectsSampleStrategy(SampleStrategy $strategy, bool $expected): void
+    public function testIncludeSamplesReflectsSampleStrategy(bool $strategyType, bool $expected): void
     {
+        $strategy = $this->makeSampleStrategy($strategyType);
+
         $this->transaction->sampleStrategy($strategy);
 
         $this->assertEquals($expected, $this->transaction->includeSamples());
     }
 
-    public function includeSamplesChecks(): array
+    public static function includeSamplesChecks(): array
     {
         return [
-            'include' => [$this->makeIncludeStrategy(), true],
-            'exclude' => [$this->makeExcludeStrategy(), false],
+            'include' => [true, true],
+            'exclude' => [false, false],
         ];
     }
 
     /**
      * @dataProvider isSampledChecks
      */
-    public function testIsSampledIsAlwaysTrue(SampleStrategy $strategy): void
+    public function testIsSampledIsAlwaysTrue(bool $strategyType): void
     {
+        $strategy = $this->makeSampleStrategy($strategyType);
+
         $this->transaction->sampleStrategy($strategy);
 
         $this->assertTrue($this->transaction->isSampled());
     }
 
-    public function isSampledChecks(): array
+    public static function isSampledChecks(): array
     {
         return [
-            'include' => [$this->makeIncludeStrategy()],
-            'exclude' => [$this->makeExcludeStrategy()],
+            'include' => [true],
+            'exclude' => [false],
         ];
     }
 
     /**
      * @dataProvider isSampledChecks
      */
-    public function testSampledAttributeReflectsStrategy(SampleStrategy $strategy): void
+    public function testSampledAttributeReflectsStrategy(bool $strategyType): void
     {
+        $strategy = $this->makeSampleStrategy($strategyType);
+
         $this->transaction->sampleStrategy($strategy);
 
         $payload = json_decode(json_encode($this->transaction), true);
@@ -214,8 +220,10 @@ final class TransactionTest extends SchemaTestCase
     /**
      * @dataProvider isSampledChecks
      */
-    public function testContextAttributeReflectsStrategy(SampleStrategy $strategy): void
+    public function testContextAttributeReflectsStrategy(bool $strategyType): void
     {
+        $strategy = $this->makeSampleStrategy($strategyType);
+
         $this->transaction->sampleStrategy($strategy);
 
         $payload = json_decode(json_encode($this->transaction), true);

--- a/tests/Factory/ConnectorFactoryTest.php
+++ b/tests/Factory/ConnectorFactoryTest.php
@@ -38,7 +38,7 @@ class ConnectorFactoryTest extends TestCase
         $this->assertEquals($headerValue, $credentials->authorizationHeaderValue());
     }
 
-    public function credentialChecks(): array
+    public static function credentialChecks(): array
     {
         return [
             'secret token' => [['secretToken' => 'abc123'], 'Bearer abc123'],

--- a/tests/Helper/EncodingTest.php
+++ b/tests/Helper/EncodingTest.php
@@ -51,7 +51,7 @@ final class EncodingTest extends TestCase
         $this->assertEquals($input, Encoding::keywordField($input));
     }
 
-    public function emptyInputChecks(): array
+    public static function emptyInputChecks(): array
     {
         return [
             'empty string' => [''],

--- a/tests/Middleware/ConnectorTest.php
+++ b/tests/Middleware/ConnectorTest.php
@@ -22,9 +22,9 @@ class ConnectorTest extends TestCase
 
     // TODO Requests to APM are the most important function of this package, we need more test coverage here
 
-    public function __construct()
+    protected function setUp(): void
     {
-        parent::__construct();
+        parent::setUp();
 
         $this->credential = new CredentialSecretToken($this->secretToken);
     }

--- a/tests/SchemaTestCase.php
+++ b/tests/SchemaTestCase.php
@@ -72,7 +72,7 @@ abstract class SchemaTestCase extends TestCase
      *
      * @return array
      */
-    abstract public function schemaVersionDataProvider(): array;
+    abstract public static function schemaVersionDataProvider(): array;
 
     protected function findUntestedSupportedSchemaVersions(): array
     {


### PR DESCRIPTION
Update to PHPUnit 10 for PHP 8.1 and higher. Required for compatibility with PHP 8.4.