### PR TITLE
Add sharedContext to spans metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name" : "davidmanassa/elastic-apm-php-agent",
+    "name" : "nipwaayoni/elastic-apm-php-agent",
     "description": "A php agent for Elastic APM v2 Intake API",
     "license": "MIT",
     "require" : {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name" : "nipwaayoni/elastic-apm-php-agent",
+    "name" : "davidmanassa/elastic-apm-php-agent",
     "description": "A php agent for Elastic APM v2 Intake API",
     "license": "MIT",
     "require" : {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -58,9 +58,9 @@ class Agent implements ApmAgent
      * @var array
      */
     private $sharedContext = [
-      'user'   => [],
-      'custom' => [],
-      'tags'   => []
+        'user'   => [],
+        'custom' => [],
+        'tags'   => []
     ];
 
     /**
@@ -103,7 +103,7 @@ class Agent implements ApmAgent
         $this->connector = $connector;
         $this->connector->useHttpUserAgentString($this->httpUserAgent());
         // TODO Why is the metadata added here and conditionally in the send() method?
-        $this->connector->putEvent(new Metadata([], $this->config, $this->agentMetadata()));
+        $this->connector->putEvent(new Metadata($this->sharedContext, $this->config, $this->agentMetadata()));
 
         $this->logger = new NullLogger();
     }
@@ -288,9 +288,8 @@ class Agent implements ApmAgent
         }
 
         // Put the preceding Metadata
-        // TODO -- add context ?
         if ($this->connector->isPayloadSet() === false) {
-            $this->putEvent(new Metadata([], $this->config, $this->agentMetadata()));
+            $this->putEvent(new Metadata($this->sharedContext, $this->config, $this->agentMetadata()));
             $this->logger->debug('Payload is empty, added metadata');
         }
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -310,7 +310,7 @@ class Agent implements ApmAgent
     /**
      * Get sharedContext
      */
-    public function getSharedContext(): array
+    public function getSharedContext(): array | ContextCollection
     {
         return $this->sharedContext;
     }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -306,4 +306,12 @@ class Agent implements ApmAgent
 
         $this->logger->debug('Sent data to Elastic APM host');
     }
+
+    /**
+     * Get sharedContext
+     */
+    public function getSharedContext(): array
+    {
+        return $this->sharedContext;
+    }
 }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -55,7 +55,7 @@ class Agent implements ApmAgent
     /**
      * Common/Shared Contexts for Errors and Transactions
      *
-     * @var array
+     * @var array | \Nipwaayoni\Contexts\ContextCollection
      */
     private $sharedContext = [
         'user'   => [],
@@ -103,7 +103,7 @@ class Agent implements ApmAgent
         $this->connector = $connector;
         $this->connector->useHttpUserAgentString($this->httpUserAgent());
         // TODO Why is the metadata added here and conditionally in the send() method?
-        $this->connector->putEvent(new Metadata($this->sharedContext, $this->config, $this->agentMetadata()));
+        $this->connector->putEvent(new Metadata($this->sharedContext->toArray(), $this->config, $this->agentMetadata()));
 
         $this->logger = new NullLogger();
     }
@@ -289,7 +289,7 @@ class Agent implements ApmAgent
 
         // Put the preceding Metadata
         if ($this->connector->isPayloadSet() === false) {
-            $this->putEvent(new Metadata($this->sharedContext, $this->config, $this->agentMetadata()));
+            $this->putEvent(new Metadata($this->sharedContext->toArray(), $this->config, $this->agentMetadata()));
             $this->logger->debug('Payload is empty, added metadata');
         }
 


### PR DESCRIPTION
Adds sharedContext to spans metadata. Necessary, for example, for the use of [global labels](https://www.elastic.co/guide/en/apm/agent/go/current/configuration.html#config-global-labels).